### PR TITLE
Include Lighthouse, Teku and Nimbus in the guide for staking with k8s

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,12 +11,12 @@ enableRobotsTXT = true
 
 [languages]
   [languages.en]
-    contentDir = "content/en/posts"
+    contentDir = "content/en"
     title = "lumostone"
     languageName = "English"
     weight = 1
   [languages.zh-tw]
-    contentDir = "content/zh-tw/posts"
+    contentDir = "content/zh-tw"
     title = "lumostone"
     languageName = "繁體中文"
     weight = 2

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -1,0 +1,616 @@
+---
+title: "Guide to Ethereum 2.0 Staking with Kubernetes and Prysm"
+date: 2021-04-19T23:53:09Z
+draft: false
+tags: ["ethereum", "kubernetes", "tutorial"]
+---
+
+## Why Stake with Kubernetes? 
+As stakers, we all want to minimize downtime and the risk of being slashed. 
+
+Minimizing downtime is a difficult objective to achieve since a validator might be down for various reasons: system failures, incomplete restart policies, connectivity issues, hardware maintenance or software bugs. Staking with two or more machines for redundancy naturally comes to mind.
+
+People might say, “redundancy leads to slashing!” which is a legitimate concern because we could accidentally run multiple validators with the same validator keys at the same time. Migrating the validators from a broken machine to the other with inappropriate procedure might in turn corrupt the slashing protection database . A staker with benign intention has the risk of being slashed due to the error-prone manual operations and the complexities increase when you have a high-availability setup. Needless to say, the experience could deteriorate if a staker runs multiple validators.
+
+_Can we reduce the risk and the complexities of staking while running multiple validators and embracing redundancy?_ Yes, we think [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) can help us manage the application’s lifecycle and automate the upgrade rollouts. The process of upgrading a client would be completed in one-step. Furthermore, migrating a client from one machine to another also would be a single command (*e.g.* kubectl drain node). 
+
+We hope this experiment and the setup guide can be a stepping stone for the community to stake with Kubernetes for Ethereum 2.0. Embrace the redundancy and stake with ease and scalability.
+
+## Acknowledgement
+We want to thank Ethereum Foundation for supporting this project via the [Eth2 Staking Community Grants](https://blog.ethereum.org/2021/02/09/esp-staking-community-grantee-announcement/). It’s an honor to contribute to this community! 
+
+## Technologies
+
+In this step-by-step guide, we run one beacon node with multiple validator clients in a Kuberenetes cluster for Ethereum 2.0 staking. We are using:
+
+- [Prysm](https://github.com/prysmaticlabs/prysm) as the Ethereum 2.0 Client.
+- [MicroK8s](https://microk8s.io/) as the Kubernertes destribution ([installation guide](https://microk8s.io/docs)).
+- [Helm 3](https://helm.sh/) to manage packages and releases.
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) to run commands against Kubernetes clusters.
+- Ubuntu Server 20.04.2 LTS (x64) ([download link](https://ubuntu.com/download/server)).
+- [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) as beacon and validator clients’ persistent storage ([Guide for NFS installation and configuration on Ubuntu](https://ubuntu.com/server/docs/service-nfs)).
+- [eth2xk8s](https://github.com/lumostone/eth2xk8s) Helm Chart.
+
+## Goal
+
+This guide will help you to:
+
+- Create a Kubernetes cluster with MicroK8s. If you already have your prefered Kubernetes distribution running you can jump to the section “[Install and Configure NFS](#install-and-configure-nfs)”. If you are using managed Kubernetes services provided by cloud providers (*e.g.* AKS, EKS, and GKE), you may consider using cloud storage directly rather than NFS as the persistent storage. We will cover this topic in the future.
+- Install and configure NFS.
+- Prepare the Helm Chart for multiple validator clients.
+- Install Prysm’s beacon and validator clients with the Helm Chart.
+- Check client status.
+- Upgrade and roll back the Prysm’s beacon and validator clients with the Helm Chart.
+
+## Non-Goal
+
+This guide does not cover the following topics:
+
+- Performance tuning and sizing.
+- Guide to fund the validators and to generate the validator keys.
+- Kubernetes cluster high availability (HA) configuration.
+- Kubernetes cluster security hardening.
+
+## Disclaimer
+
+As of today, this setup has been tested in the testnet only. 
+
+We all stake at our own risk. Please always do the experiments and dry-run on the testnet first, familiarize yourself with all the operations, and harden your systems before running it on the mainnet. This guide serves as a stepping stone for staking with Kubernetes. **The authors are not responsible for any financial losses incurred by following this guide.**
+
+## System Requirements
+
+We need at least 3 machines (virtual machines or bare-metal machines) in total for this setup. One machine will be the NFS server to store the staking data, the second machine will be the “master” node to run the Kubernetes core components, and finally, the third machine will be the “worker” node to run the workloads, which are the beacon and validator clients, in the Kubernetes cluster. For high availability (HA), you can consider adding more nodes by following [MicroK8s’ High Availability documentation](https://microk8s.io/docs/high-availability) and regularly backing up the beacon data for fast startup. We will discuss HA configurations in subsequent posts. 
+
+Here are the recommended system requirements based on our testing on the [**Prater testnet**](https://prater.beaconcha.in/) and [MicroK8s’ documentation](https://microk8s.io/docs). **Please note that meeting the minimal requirements does not guarantee optimal performance or cost efficiency.**
+
+Master:
+
+- RAM: 8 GB minimum
+- CPU: 1 core minimum
+- Disk: 20 GB minimum
+
+Worker:
+
+- RAM: 8 GB minimum
+- CPU: 1 core minimum
+- Disk: 20 GB minimum
+
+NFS:
+
+- RAM: 2 GB minimum
+- CPU: 1 core minimum
+- Disk: 250 GB minimum (Again, please note it is for testnet. For running on the mainnet, you may need more storage.)
+
+## Network Requirements
+
+- Every machine needs to have outbound connectivity to the Internet at least during installation. 
+- Masters and workers can reach to each other. We will configure the firewall in the following section to only allow the inbound traffic to the ports required by MicroK8s. For more details, you can refer to [MicroK8s’ documentation: Services and ports](https://microk8s.io/docs/ports).
+- Masters and workers can reach the NFS server.
+- Masters and workers can reach the endpoint of the Ethereum 1.0 “Goerli” node (Please refer to [Prerequisites](#prerequisites) for more information).
+
+## Prerequisites
+
+- You have funded your validators and have generated validator keys. If you need guidance, we recommend [Somer Esat’s guide](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3).
+- Ethereum 1.0 “Goerli” node: [Somer Esat’s guide](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3) also covers steps for building the Ethereum 1.0 node. You can also choose a third-party provider such as [Infura](https://infura.io/) or [Alchemy](https://alchemyapi.io/).
+- Planning your private network, firewall, and port forwarding. We have put our network configuration in the [Walkthrough](#overview) for your reference.
+- You have installed Ubuntu Server 20.04.2 LTS (x64) on all the servers and have assigned static IPs.
+
+## Walkthrough
+
+### Overview
+
+In this walkthrough, we will set up a Kubernetes cluster and a NFS server and install the beacon node and the validator clients. We put all the machines in the same private subnet and have assigned a static private IP for each machine. Here are the network configurations we use throughout this guide for the three machines:
+
+**Private subnet: 172.20.0.0/20 (172.20.0.1 - 172.20.15.254)**
+- NFS IP: 172.20.10.10
+- Master IP: 172.20.10.11
+- Worker IP: 172.20.10.12
+- DNS: 8.8.8.8, 8.8.4.4 (Google’s DNS)
+
+### System Update/Upgrade
+
+Please run the commands below on all the machines:
+
+```bash
+sudo apt update && sudo apt upgrade
+sudo apt dist-upgrade && sudo apt autoremove
+sudo reboot
+```
+
+### Time Sync
+
+Perform the following steps on all the machines:
+
+1. Set your timezone. Using `America/Los_Angeles` as an example:
+
+    ```bash
+    timedatectl list-timezones
+    sudo timedatectl set-timezone America/Los_Angeles
+    ```
+
+2. Confirm that the default timekeeping service is on (NTP service). 
+
+    ```bash
+    timedatectl
+    ```
+
+3. Install `chrony`.
+
+    ```bash
+    sudo apt install chrony
+    ```
+
+4. Edit the `chrony` configuration.
+
+    ```bash
+    sudo nano /etc/chrony/chrony.conf
+    ```
+
+    Add the following pools as the clock sources:
+
+    ```bash
+    pool time.google.com     iburst minpoll 1 maxpoll 2 maxsources 3
+    pool us.pool.ntp.org     iburst minpoll 1 maxpoll 2 maxsources 3
+    pool ntp.ubuntu.com      iburst minpoll 1 maxpoll 2 maxsources 3
+    ```
+
+    Update the two settings:
+
+    ```bash
+    maxupdateskew 5.0 # The threshold for determining whether an estimate is too unreliable to be used.
+    makestep 0.1 -1  # This would step the system clock if the adjustment is larger than 0.1 seconds.
+    ```
+
+5. Restart the `chronyd` service.
+
+    ```bash
+    sudo systemctl restart chronyd
+    ```
+
+6. To see the source of synchronization data.
+
+    ```bash
+    chronyc sources
+    ```
+
+    To view the current status of `chrony`.
+
+    ```bash
+    chronyc tracking
+    ```
+
+### Configure Firewall
+
+Perform step 1-3 on all the machines:
+
+1. Set up default rules.
+
+    ```bash
+    sudo ufw default deny incoming
+    sudo ufw default allow outgoing
+    ```
+
+2. (**Optional**) We suggest changing the ssh port from `22` to another port for security. You can open the `sshd_config` config file and change `Port 22` to your designated port:
+
+    ```bash
+    sudo nano /etc/ssh/sshd_config
+    ```
+
+    Then restart the `ssh` service.
+
+    ```bash
+    sudo service sshd restart
+    ```
+
+3. No matter which port is used, remember to allow inbound traffic to your ssh port over TCP:
+
+    ```bash
+    sudo ufw allow <ssh-port>/tcp
+    ```
+
+4. On the NFS server, add the rule for NFS service:
+
+    ```bash
+    sudo ufw allow 2049/tcp
+    ```
+
+5. On the master and worker machines, add the rules for MicroK8s services:
+
+    ```bash
+    sudo ufw allow 16443/tcp
+    sudo ufw allow 10250/tcp
+    sudo ufw allow 10255/tcp
+    sudo ufw allow 25000/tcp
+    sudo ufw allow 12379/tcp
+    sudo ufw allow 10257/tcp
+    sudo ufw allow 10259/tcp
+    sudo ufw allow 19001/tcp
+    ```
+
+6. On the master and worker machines, add the rules for beacon node:
+
+    ```bash
+    sudo ufw allow 12000/udp
+    sudo ufw allow 13000/tcp
+    ```
+
+7. Lastly, enable the firewall on each machine.
+
+    ```bash
+    sudo ufw enable
+    sudo ufw status numbered
+    ```
+
+### Install MicroK8s
+
+To install MicroK8s, you can refer to [MicroK8s’ installation guide](https://microk8s.io/docs) or follow the instructions below on both of the master and worker machines.
+
+1. Install and run MicroK8s.
+
+    ```bash
+    sudo snap install microk8s --classic --channel=1.20/stable
+    ```
+
+2. To grant your non-root user the admin privilege to execute MicroK8s commands, add the user to the MicroK8s group and change the owner of `~/.kube` directory.
+
+    ```bash
+    sudo usermod -a -G microk8s $USER
+    sudo chown -f -R $USER ~/.kube
+
+    su - $USER # Re-enter the session for the update to take place.
+    ```
+
+3. Wait for MicroK8s to be ready.
+
+    ```bash
+    microk8s status --wait-ready
+    ```
+
+4. Double check the node is ready.
+
+    ```bash
+    microk8s kubectl get node
+    ```
+
+    You should only see one node in the result.
+
+### Set up a Cluster
+
+Please finish the previous section and make sure MicroK8s is running on both master and worker machines before proceeding.
+
+On the master:
+
+1. Enable DNS and Helm 3.
+
+    ```bash
+    microk8s enable dns helm3
+    ```
+
+2. Use the add-node command to generate a connection string for the worker node to join the cluster.
+
+    ```bash
+    microk8s add-node
+    ```
+
+    You should see output like this:
+
+    ```bash
+    Join node with:
+    microk8s join 172.31.20.243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+
+    If the node you are adding is not reachable through the default
+    interface you can use one of the following:
+
+    microk8s join 172.31.20.243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+    microk8s join 10.1.84.0:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+    ```
+
+On the worker:
+
+1. Copy the join command and join the cluster. For example,
+
+    ```bash
+    microk8s join 172.31.20.243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+    ```
+
+2. After the joining is done, check whether the worker node is in the cluster.
+
+    ```bash
+    microk8s kubectl get node
+    ```
+
+    You should see both master and worker nodes in the result.
+
+### Install and Configure NFS
+
+You can refer to the [Ubuntu's documentation: NFS installation and configuration](https://ubuntu.com/server/docs/service-nfs) or follow the instructions below.
+
+On the machine you plan to run NFS:
+
+1. Install and start the NFS server.
+
+    ```bash
+    sudo apt install nfs-kernel-server
+    sudo systemctl start nfs-kernel-server.service
+    ```
+
+2. Create directories for the beacon node, validator clients, and wallets.
+
+    ```bash
+    sudo mkdir -p /data/prysm/beacon
+
+    sudo mkdir -p /data/prysm/validator-client-1 /data/prysm/wallet-1
+    sudo mkdir -p /data/prysm/validator-client-2 /data/prysm/wallet-2
+    ```
+
+   **Please note that each wallet can only be used by a single validator client.** You can import multiple validator keys into the same wallet and use one validator client to attest/propose blocks for multiple validators. 
+    
+    _To avoid slashing, do not use multiple validator clients with the same wallet or have the same key imported into different wallets used by different validator clients._
+
+3. Configure and export NFS storage.
+
+    ```bash
+    sudo nano /etc/exports
+    ```
+
+    Add the following and save the file:
+
+    ```bash
+    /data *(rw,sync,no_subtree_check)
+    ```
+
+    Option descriptions:
+
+    - **\***: hostname format.
+    - **rw**: read/write permission.
+    - **sync**: changes are guaranteed to be committed to stable storage before replying to requests.
+    - **no_subtree_check**: disables subtree checking, which has mild security implications, but can improve reliability in some circumstances. From release 1.1.0 of nfs-utils onwards, the default is no_subtree_check as subtree_checking tends to cause more problems than it is worth.
+
+    Please see the [NFS server export table manual](https://man7.org/linux/man-pages/man5/exports.5.html) for more details.
+
+    Export the config
+
+    ```bash
+    sudo exportfs -a
+    ```
+
+
+4. On your master and worker nodes, enable NFS support by installing `nfs-common`:
+
+    ```bash
+    sudo apt install nfs-common
+    ```
+
+### Prepare Validator Wallets
+
+Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm).
+
+Let’s get back to the NFS server. Before proceeding, please have your validator keys placed on your NFS machine. We are going to prepare the wallet with wallet directories that we created in the previous section, and then import the validator keys into the wallet. To create a wallet and import your validator keys for Prysm validator clients, we use Prysm’s startup script.
+
+1. Please follow [Prysm’s documentation](https://docs.prylabs.network/docs/install/install-with-script/#downloading-the-prysm-startup-script) to download Prysm startup script.
+
+2. Execute the startup script with `--keys-dir=<path/to/validator-keys>` (Remember to replace it with the directory you place the keys). We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys.
+
+    ```bash
+    sudo ./prysm.sh validator accounts import --keys-dir=$HOME/eth2.0-deposit-cli/validator_keys
+    ```
+
+3. When prompted, enter your wallet directory. For example, `/data/prysm/wallet-1`
+
+4. Create the wallet password (**remember to back it up somewhere safe!**)
+
+5. Enter the password you used to create the validator keys with the [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli). If you enter it correctly, the accounts will be imported into the new wallet.
+
+### Change the owner of the data folder
+
+On the NFS machine, let’s change the directory owners so later these directories can be mounted by Kubernetes as the storage volumes for the pods running the beacon node and the validator clients. 
+
+```bash
+sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
+```
+
+### Prepare the Helm Chart
+
+We understand it is not trivial to learn Kubernetes and create manifests or Helm Charts for staking from scratch, so we’ve already done this for you to help you bootstrap! We uploaded all the manifests in our Github repository [eth2xk8s](https://github.com/lumostone/eth2xk8s).
+
+We use Helm to manage packages and releases in this guide. You can also use Kubernetes manifests directly. Please see [Testing manifests with Prysm and hostPath](https://github.com/lumostone/eth2xk8s/blob/master/prysm/host-path/README.md) and [Testing manifests with Prysm and NFS](https://github.com/lumostone/eth2xk8s/blob/master/prysm/nfs/README.md) for details.
+
+1. Clone this repo.
+
+    ```bash
+    git clone https://github.com/lumostone/eth2xk8s.git
+    ```
+
+2. Change values in [./prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml).
+
+    We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
+    - **nfs.serverIp**: NFS server IP address.
+    - **nfs.user**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
+    - **nfs.group**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
+    - **image.version**: Prysm client version.
+    - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
+    - **beacon.web3Provider** and **beacon.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
+    - **validatorClients.validatorClient1.dataVolumePath**: The path to the data directory on the NFS for the validator client.
+    - **validatorClients.validatorClient1.walletVolumePath**: The path to the data directory on the NFS for the wallet.
+    - **validatorClients.validatorClient1.walletPassword**: The wallet password.
+
+### Install Prysm via Helm Chart
+
+Kubernetes has the concept of [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) to define scopes for names and isolate accesses between resources. We use `prysm` as the namespace for the Prysm client. 
+
+Helm uses [releases](https://helm.sh/docs/glossary/#release) to track each of the chart installations. In this guide, we specify our release name as `eth2xk8s`, you can change it to anything you prefer.
+
+On your master:
+
+1. Create the namespace.
+
+    ```bash
+    microk8s kubectl create namespace prysm
+    ```
+
+2. Install the Prysm client.
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./prysm/helm -nprysm
+    ```
+
+3. Check the configurations used.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nprysm
+    ```
+
+### Check Client Status
+
+1. Check the deployment status.
+
+    ```bash
+    microk8s kubectl get pod -nprysm -w
+    ```
+
+    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in RUNNING status.
+
+2. Check the log of the beacon node.
+
+    ```bash
+    microk8s kubectl logs -f -nprysm -l app=beacon
+    ```
+
+3. Check the log of the first validator client.
+
+    ```bash
+    microk8s kubectl logs -f -nprysm -l app=validator-client-1
+    ```
+
+    To check other validator clients, change `-l app=<validator client name>` to other validator clients’ names specified in `values.yaml`, *e.g.* for checking the second validator client.
+
+    ```bash
+    microk8s kubectl logs -f -nprysm -l app=validator-client-2
+    ```
+
+### Upgrade the Prysm Version with Helm Chart
+
+Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we should try to keep up with the new releases to get the up-to-date patches and features! We suggest using Helm for upgrading to leverage its releases and lifecycle management:
+
+1. Check [Prysm Github release page](https://github.com/prysmaticlabs/prysm/releases) to get the latest release version.
+
+2. Modify the `image.version` in `values.yaml` to the latest version, *e.g.* `v1.3.4`, and save the change in `values.yaml`.
+
+3. Upgrade the client with the Helm upgrade command.
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./prysm/helm -nprysm
+    ```
+
+4. Check the configurations to see if it picks up the new version correctly.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nprysm
+    ```
+
+5. Refer to [Check Client Status](#check-client-status) section to verify the client is running without issues.
+
+### Roll Back the Release with Helm
+
+Rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. You can follow the steps below: 
+
+1. Check Helm release history and find a “good” release. Note the target revision number.
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nprysm
+    ```
+
+2. If we want to roll back to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nprysm
+    ```
+
+3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
+
+If the rollback involves schema changes, please refer to [Appendix: Roll Back the Release with Helm (Schema Changes)](#roll-back-the-release-with-helm-schema-changes) for details.
+
+Sometimes, it’s not possible to downgrade to previous versions like described [here](https://docs.prylabs.network/docs/prysm-usage/staying-up-to-date/#downgrading-between-major-version-bumps). Please refer to the client team’s documentations for details before you downgrade the client.
+
+## Conclusion
+
+Thank you for reading to the end of this guide! We hope this guide paves the way for staking with Kubernetes. We will continue to contribute more guides about staking with Kubernetes to the community. We are currently developing the Helm Chart and guides for other Ethereum 2.0 clients. Stay tuned!
+
+## Feedback
+
+We would love to hear from you! Let us know what you think.
+
+- If you have any suggestions or questions regarding this guide, feel free to open issues or pull requests in our [website](https://github.com/lumostone/lumostone.github.io) repository.
+- If you would like to contribute to the Helm Chart, open issues or pull requests in [eth2xk8s](https://github.com/lumostone/eth2xk8s) repository.
+
+## Appendix
+
+### Check CPU / Memory Usage
+
+You can use [metrics server](https://github.com/kubernetes-sigs/metrics-server) to check the CPU/Memory usage of each pod.
+
+1. Install metrics server on the cluster:
+
+    ```bash
+    microk8s kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+    ```
+
+2. Run the `kubectl top` command, for example:
+
+    ```bash
+    microk8s kubectl top pod -l app=beacon
+    microk8s kubectl top pod -l app=validator-client-1
+    ```
+
+### Uninstall Helm Chart
+
+If you want to stop and uninstall the Prysm client, you can uninstall the Helm Chart with the following command:
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nprysm
+```
+
+### Roll Back the Release with Helm (Schema Changes)
+
+Take [Prysm v1.3.0 release](https://github.com/prysmaticlabs/prysm/releases/tag/v1.3.0) as an example. If you decide to roll back to v1.2.x after upgrading to v1.3.0, you’ll need to run a script first to reverse the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
+
+Hence, we can take advantage of Kubernetes to help us temporarily scale down the pods and then to run the reverse migration script before rolling back.
+
+1. Before rolling back the release, scale down the target deployment, *e.g*. scale down beacon node
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nprysm --replicas=0
+    ```
+
+    or scale down validator-client-1 if the schema changes only affect validators
+
+    ```bash
+    microk8s kubectl scale deployments/validator-client-1 -nprysm --replicas=0
+    ```
+
+2. Confirm that the pod(s) are terminated.
+
+    ```bash
+    microk8s kubectl get pod -nprysm -w
+    ```
+
+3. Run the reverse migration script.
+
+4. Roll back the release to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nprysm
+    ```
+
+5. Scale up the deployment.
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nprysm --replicas=1
+    microk8s kubectl scale deployments/validator-client-1 -nprysm --replicas=1
+    ```
+
+6. Confirm that the pod(s) are running.
+
+    ```bash
+    microk8s kubectl get pod -nprysm -w
+    ```

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -481,7 +481,7 @@ On the machine you plan to run NFS:
     sudo apt install nfs-common
     ```
 
-### Prepare Validator Wallets
+### Import Validator Keys
 
 Let’s get back to the NFS server to import the validator keys created with [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli). Before proceeding, please have your validator keys placed on your NFS machine.
 {{< toggle-panel name="Prysm" active=true >}}

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -1,31 +1,54 @@
 ---
 title: "Guide to Ethereum 2.0 Staking with Kubernetes"
-date: 2021-04-19T23:53:09Z
+date: 2021-05-07T23:53:09Z
 draft: true
 tags: ["ethereum", "kubernetes", "tutorial"]
 ---
 
+> On May 10, 2020, this guide has been updated to include Lighthouse, Teku and Nimbus clients along with Prysm, the Ethereum 2.0 client we started with.
+
 {{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" >}}
 
-## Why Stake with Kubernetes? 
-As stakers, we all want to minimize downtime and the risk of being slashed. 
+## Why Stake with Kubernetes?
+
+As stakers, we all want to minimize downtime and the risk of being slashed.
 
 Minimizing downtime is a difficult objective to achieve since a validator might be down for various reasons: system failures, incomplete restart policies, connectivity issues, hardware maintenance or software bugs. Staking with two or more machines for redundancy naturally comes to mind.
 
 People might say, “redundancy leads to slashing!” which is a legitimate concern because we could accidentally run multiple validators with the same validator keys at the same time. Migrating the validators from a broken machine to the other with inappropriate procedure might in turn corrupt the slashing protection database . A staker with benign intention has the risk of being slashed due to the error-prone manual operations and the complexities increase when you have a high-availability setup. Needless to say, the experience could deteriorate if a staker runs multiple validators.
 
-_Can we reduce the risk and the complexities of staking while running multiple validators and embracing redundancy?_ Yes, we think [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) can help us manage the application’s lifecycle and automate the upgrade rollouts. The process of upgrading a client would be completed in one-step. Furthermore, migrating a client from one machine to another also would be a single command (*e.g.* kubectl drain node). 
+_Can we reduce the risk and the complexities of staking while running multiple validators and embracing redundancy?_ Yes, we think [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) can help us manage the application’s lifecycle and automate the upgrade rollouts. The process of upgrading a client would be completed in one-step. Furthermore, migrating a client from one machine to another also would be a single command (*e.g.* kubectl drain node).
 
 We hope this experiment and the setup guide can be a stepping stone for the community to stake with Kubernetes for Ethereum 2.0. Embrace the redundancy and stake with ease and scalability.
 
 ## Acknowledgement
-We want to thank Ethereum Foundation for supporting this project via the [Eth2 Staking Community Grants](https://blog.ethereum.org/2021/02/09/esp-staking-community-grantee-announcement/). It’s an honor to contribute to this community! 
+
+We want to thank Ethereum Foundation for supporting this project via the [Eth2 Staking Community Grants](https://blog.ethereum.org/2021/02/09/esp-staking-community-grantee-announcement/). It’s an honor to contribute to this community!
 
 ## Technologies
 
 In this step-by-step guide, we run one beacon node with multiple validator clients in a Kuberenetes cluster for Ethereum 2.0 staking. We are using:
 
-- [Prysm](https://github.com/prysmaticlabs/prysm) as the Ethereum 2.0 Client.
+- {{< toggle-panel name="Prysm" num="1" >}}
+
+[Prysm](https://github.com/prysmaticlabs/prysm) as the Ethereum 2.0 Client.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+[Lighthouse](https://github.com/sigp/lighthouse) as the Ethereum 2.0 Client.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+[Teku](https://github.com/ConsenSys/teku) as the Ethereum 2.0 Client.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+[Nimbus](https://github.com/status-im/nimbus-eth2) as the Ethereum 2.0 Client.
+
+{{< /toggle-panel >}}
 - [MicroK8s](https://microk8s.io/) as the Kubernertes destribution ([installation guide](https://microk8s.io/docs)).
 - [Helm 3](https://helm.sh/) to manage packages and releases.
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) to run commands against Kubernetes clusters.
@@ -37,12 +60,12 @@ In this step-by-step guide, we run one beacon node with multiple validator clien
 
 This guide will help you to:
 
-- Create a Kubernetes cluster with MicroK8s. If you already have your prefered Kubernetes distribution running you can jump to the section “[Install and Configure NFS](#install-and-configure-nfs)”. If you are using managed Kubernetes services provided by cloud providers (*e.g.* AKS, EKS, and GKE), you may consider using cloud storage directly rather than NFS as the persistent storage. We will cover this topic in the future.
+- Create a Kubernetes cluster with MicroK8s. If you already have your preferred Kubernetes distribution running you can jump to the section “[Install and Configure NFS](#install-and-configure-nfs)”. If you are using managed Kubernetes services provided by cloud providers (*e.g.* AKS, EKS, and GKE), you may consider using cloud storage directly rather than NFS as the persistent storage. We will cover this topic in the future.
 - Install and configure NFS.
-- Prepare the Helm Chart for multiple validator clients.
-- Install Prysm’s beacon and validator clients with the Helm Chart.
+- Prepare the Helm Chart for multiple clients.
+- Install Ethereum 2.0 clients with the Helm Chart.
 - Check client status.
-- Upgrade and roll back the Prysm’s beacon and validator clients with the Helm Chart.
+- Upgrade and roll back the Ethereum 2.0 clients with the Helm Chart.
 
 ## Non-Goal
 
@@ -55,13 +78,13 @@ This guide does not cover the following topics:
 
 ## Disclaimer
 
-As of today, this setup has been tested in the testnet only. 
+As of today, this setup has been tested in the testnet only.
 
 We all stake at our own risk. Please always do the experiments and dry-run on the testnet first, familiarize yourself with all the operations, and harden your systems before running it on the mainnet. This guide serves as a stepping stone for staking with Kubernetes. **The authors are not responsible for any financial losses incurred by following this guide.**
 
 ## System Requirements
 
-We need at least 3 machines (virtual machines or bare-metal machines) in total for this setup. One machine will be the NFS server to store the staking data, the second machine will be the “master” node to run the Kubernetes core components, and finally, the third machine will be the “worker” node to run the workloads, which are the beacon and validator clients, in the Kubernetes cluster. For high availability (HA), you can consider adding more nodes by following [MicroK8s’ High Availability documentation](https://microk8s.io/docs/high-availability) and regularly backing up the beacon data for fast startup. We will discuss HA configurations in subsequent posts. 
+We need at least 3 machines (virtual machines or bare-metal machines) in total for this setup. One machine will be the NFS server to store the staking data, the second machine will be the “master” node to run the Kubernetes core components, and finally, the third machine will be the “worker” node to run the workloads, which are the beacon and validator clients, in the Kubernetes cluster. For high availability (HA), you can consider adding more nodes by following [MicroK8s’ High Availability documentation](https://microk8s.io/docs/high-availability) and regularly backing up the beacon data for fast startup. We will discuss HA configurations in subsequent posts.
 
 Here are the recommended system requirements based on our testing on the [**Prater testnet**](https://prater.beaconcha.in/) and [MicroK8s’ documentation](https://microk8s.io/docs). **Please note that meeting the minimal requirements does not guarantee optimal performance or cost efficiency.**
 
@@ -85,7 +108,7 @@ NFS:
 
 ## Network Requirements
 
-- Every machine needs to have outbound connectivity to the Internet at least during installation. 
+- Every machine needs to have outbound connectivity to the Internet at least during installation.
 - Masters and workers can reach to each other. We will configure the firewall in the following section to only allow the inbound traffic to the ports required by MicroK8s. For more details, you can refer to [MicroK8s’ documentation: Services and ports](https://microk8s.io/docs/ports).
 - Masters and workers can reach the NFS server.
 - Masters and workers can reach the endpoint of the Ethereum 1.0 “Goerli” node (Please refer to [Prerequisites](#prerequisites) for more information).
@@ -130,7 +153,7 @@ Perform the following steps on all the machines:
     sudo timedatectl set-timezone America/Los_Angeles
     ```
 
-2. Confirm that the default timekeeping service is on (NTP service). 
+2. Confirm that the default timekeeping service is on (NTP service).
 
     ```bash
     timedatectl
@@ -230,11 +253,35 @@ Perform step 1-3 on all the machines:
     ```
 
 6. On the master and worker machines, add the rules for beacon node:
+{{< toggle-panel name="Prysm" num="1" >}}
 
-    ```bash
-    sudo ufw allow 12000/udp
-    sudo ufw allow 13000/tcp
-    ```
+```bash
+sudo ufw allow 12000/udp
+sudo ufw allow 13000/tcp
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+```bash
+sudo ufw allow 9000
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+```bash
+sudo ufw allow 9000
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+```bash
+sudo ufw allow 9000
+```
+
+{{< /toggle-panel >}}
 
 7. Lastly, enable the firewall on each machine.
 
@@ -336,6 +383,8 @@ On the machine you plan to run NFS:
     sudo systemctl start nfs-kernel-server.service
     ```
 
+{{< toggle-panel name="Prysm" num="1" >}}
+
 2. Create directories for the beacon node, validator clients, and wallets.
 
     ```bash
@@ -345,11 +394,59 @@ On the machine you plan to run NFS:
     sudo mkdir -p /data/prysm/validator-client-2 /data/prysm/wallet-2
     ```
 
-   **Please note that each wallet can only be used by a single validator client.** You can import multiple validator keys into the same wallet and use one validator client to attest/propose blocks for multiple validators. 
-    
+    **Please note that each wallet can only be used by a single validator client.** You can import multiple validator keys into the same wallet and use one validator client to attest/propose blocks for multiple validator keys.
+
     _To avoid slashing, do not use multiple validator clients with the same wallet or have the same key imported into different wallets used by different validator clients._
 
-3. Configure and export NFS storage.
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+2. Create directories for the beacon node and validator clients.
+
+    ```bash
+    sudo mkdir -p /data/lighthouse/beacon
+
+    sudo mkdir -p /data/lighthouse/validator-client-1
+    sudo mkdir -p /data/lighthouse/validator-client-2
+    ```
+
+    **Please note that each key can only be used by a single validator client.** You can import multiple validator keys into the same validator client and attest/propose blocks for multiple validator keys.
+
+    _To avoid slashing, do not import the same key into different validator clients._
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+1. Create directories for the beacon node, validator clients, validator keys and key passwords.
+
+    ```bash
+    sudo mkdir -p /data/teku/beacon
+
+    sudo mkdir -p /data/teku/validator-client-1 /data/teku/validator-keys-1 /data/teku/validator-key-passwords-1
+    sudo mkdir -p /data/teku/validator-client-2 /data/teku/validator-keys-2 /data/teku/validator-key-passwords-2
+    ```
+
+    **Please note that each key can only be used by a single validator client.** You can import multiple validator keys into the same validator client and attest/propose blocks for multiple validator keys.
+
+    _To avoid slashing, do not import the same key into different validator clients._
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+2. Create directories for the beacon node, validators and secrets.
+
+    ```bash
+    sudo mkdir -p /data/nimbus/beacon-1 /data/nimbus/validators-1 /data/nimbus/secrets-1
+    sudo mkdir -p /data/nimbus/beacon-2 /data/nimbus/validators-2 /data/nimbus/secrets-2
+    ```
+
+    **Please note that each key can only be used by a single Nimbus client.** You can import multiple validator keys into the same client and attest/propose blocks for multiple validator keys.
+
+    _To avoid slashing, do not import the same key into different Nimbus clients._
+
+{{< /toggle-panel >}}
+
+1. Configure and export NFS storage.
 
     ```bash
     sudo nano /etc/exports
@@ -376,8 +473,7 @@ On the machine you plan to run NFS:
     sudo exportfs -a
     ```
 
-
-4. On your master and worker nodes, enable NFS support by installing `nfs-common`:
+2. On your master and worker nodes, enable NFS support by installing `nfs-common`:
 
     ```bash
     sudo apt install nfs-common
@@ -385,24 +481,69 @@ On the machine you plan to run NFS:
 
 ### Prepare Validator Wallets
 
-Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm).
+Let’s get back to the NFS server to import the validator keys created with [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli). Before proceeding, please have your validator keys placed on your NFS machine.
+{{< toggle-panel name="Prysm" num="1" >}}
 
-Let’s get back to the NFS server. Before proceeding, please have your validator keys placed on your NFS machine. We are going to prepare the wallet with wallet directories that we created in the previous section, and then import the validator keys into the wallet. To create a wallet and import your validator keys for Prysm validator clients, we use Prysm’s startup script.
+Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm) about how to import your validator accounts into Prysm.
 
 1. Please follow [Prysm’s documentation](https://docs.prylabs.network/docs/install/install-with-script/#downloading-the-prysm-startup-script) to download Prysm startup script.
 
 2. Execute the startup script with `--keys-dir=<path/to/validator-keys>` (Remember to replace it with the directory you place the keys). We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys.
 
     ```bash
-    sudo ./prysm.sh validator accounts import --keys-dir=$HOME/eth2.0-deposit-cli/validator_keys
+    sudo ./prysm.sh validator accounts import --keys-dir=$HOME/eth2.0-deposit-cli/validator_keys --prater
     ```
 
 3. When prompted, enter your wallet directory. For example, `/data/prysm/wallet-1`
 
 4. Create the wallet password (**remember to back it up somewhere safe!**)
 
-5. Enter the password you used to create the validator keys with the [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli). If you enter it correctly, the accounts will be imported into the new wallet.
+5. Enter the password you used to create the validator keys with the `eth2.0-deposit-cli`. If you enter it correctly, the accounts will be imported into the new wallet.
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+Please refer to [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/validator-import-launchpad.html) about how to import your validator accounts into Lighthouse.
+
+1. Please follow [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/installation-binaries.html) to download Lighthouse pre-built binary.
+
+2. Execute the binary with `--directory=<path/to/validator-keys>` (Remember to replace it with the directory you place the keys). We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys and `/data/lighthouse/validator-client-1` for the data directory of the validator client.
+
+    ```bash
+    sudo ./lighthouse --network prater account validator import --directory $HOME/eth2.0-deposit-cli/validator_keys --datadir /data/lighthouse/validator-client-1 --reuse-password
+    ```
+
+3. Enter the password you used to create the validator keys with `eth2.0-deposit-cli`. If you enter it correctly, the keys will be imported.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+Please refer to [Teku's documentation](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#generate-the-validators-and-send-the-deposits) about how to import your validator accounts into Teku.
+
+1. Copy validator keys into the target folder for keys. Assume our keys generated with `eth2.0-deposit-cli` is under `$HOME/eth2.0-deposit-cli/validator_keys` and our target folder for keys is /data/teku/validator-keys-1
+
+    ```bash
+    sudo cp  $HOME/eth2.0-deposit-cli/validator_keys/* /data/teku/validator-keys-1/
+    ```
+
+2. Create one password txt file for each corresponding key in the target folder for key passwords, `/data/teku/validator-key-passwords-1`. For example, if there's a keystore named keystore-m_123.json, you'll need to create a file named keystore-m_123.txt and store the keystore's password in it.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+Please refer to [Nimbus's documentation](https://nimbus.guide/keys.html) about how to import your validator accounts into Nimbus.
+
+1. Please follow [Nimbus's documentation](https://nimbus.guide/binaries.html) to download Nimbus pre-built binary.
+
+2. Execute the binary with `<path/to/validator-keys>` (Remember to replace it with the directory you place the keys). We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys and `/data/nimbus-1` for the data directory of the Nimbus client.
+
+    ```bash
+    sudo nimbus_beacon_node deposits import --data-dir=/data/nimbus-1 $HOME/eth2.0-deposit-cli/validator_keys
+    ```
+
+3. Enter the password you used to create the validator keys with `eth2.0-deposit-cli`. If you enter it correctly, the keys will be imported.
+
+{{< /toggle-panel >}}
 ### Change the owner of the data folder
 
 On the NFS machine, let’s change the directory owners so later these directories can be mounted by Kubernetes as the storage volumes for the pods running the beacon node and the validator clients. 
@@ -423,24 +564,79 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     git clone https://github.com/lumostone/eth2xk8s.git
     ```
 
+{{< toggle-panel name="Prysm" num="1" >}}
+
 2. Change values in [./prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml).
 
     We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
     - **nfs.serverIp**: NFS server IP address.
-    - **nfs.user**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
-    - **nfs.group**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
+    - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
+    - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
     - **image.version**: Prysm client version.
     - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
     - **beacon.web3Provider** and **beacon.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
+    - **validatorClients.validatorClient1**
+      - **.dataVolumePath**: The path to the data directory on the NFS for the validator client.
+      - **.walletVolumePath**: The path to the data directory on the NFS for the wallet.
+      - **.walletPassword**: The wallet password.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+1. Change values in [./lighthouse/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/lighthouse/helm/values.yaml).
+
+    We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
+    - **nfs.serverIp**: NFS server IP address.
+    - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
+    - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
+    - **image.version**: Lighthouse client version.
+    - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
+    - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1.dataVolumePath**: The path to the data directory on the NFS for the validator client.
-    - **validatorClients.validatorClient1.walletVolumePath**: The path to the data directory on the NFS for the wallet.
-    - **validatorClients.validatorClient1.walletPassword**: The wallet password.
 
-### Install Prysm via Helm Chart
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
 
-Kubernetes has the concept of [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) to define scopes for names and isolate accesses between resources. We use `prysm` as the namespace for the Prysm client. 
+1. Change values in [./teku/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/teku/helm/values.yaml).
+
+    We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
+    - **nfs.serverIp**: NFS server IP address.
+    - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
+    - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
+    - **image.version**: Teku client version.
+    - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
+    - **beacon.eth1Endpoint**: Ethereum 1.0 node endpoint.
+    - **validatorClients.validatorClient1**
+      - **.dataVolumePath**: The path to the data directory on the NFS for the validator client.
+      - **.validatorKeysVolumePath**: The path to the data directory on the NFS for the validator keys.
+      - **.validatorKeyPasswordsVolumePath**: The path to the data directory on the NFS for the validator key passwords.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+1. Change values in [./nimbus/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/nimbus/helm/values.yaml).
+
+    We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
+    - **nfs.serverIp**: NFS server IP address.
+    - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
+    - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
+    - **image.versionTag**: Nimbus client version.
+    - **nimbus.clients.client1**
+      - **.web3Provider** and **.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
+      - **.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
+      - **.validatorsVolumePath**: The path to the data directory on the NFS for the validator keystores.
+      - **.secretsVolumePath**: The path to the data directory on the NFS for the validator keystore passwords.
+
+{{< /toggle-panel >}}
+
+### Install Ethereum 2.0 Client via Helm Chart
 
 Helm uses [releases](https://helm.sh/docs/glossary/#release) to track each of the chart installations. In this guide, we specify our release name as `eth2xk8s`, you can change it to anything you prefer.
+
+Kubernetes has the concept of [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) to define scopes for names and isolate accesses between resources.
+
+{{< toggle-panel name="Prysm" num="1" >}}
+We use `prysm` as the namespace for the Prysm client.
 
 On your master:
 
@@ -462,7 +658,83 @@ On your master:
     microk8s helm3 get manifest eth2xk8s -nprysm
     ```
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+We use `lighthouse` as the namespace for the Lighthouse client.
+
+On your master:
+
+1. Create the namespace.
+
+    ```bash
+    microk8s kubectl create namespace lighthouse
+    ```
+
+2. Install the Lighthouse client.
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./lighthouse/helm -nlighthouse
+    ```
+
+3. Check the configurations used.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nlighthouse
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+We use `teku` as the namespace for the Teku client.
+
+On your master:
+
+1. Create the namespace.
+
+    ```bash
+    microk8s kubectl create namespace teku
+    ```
+
+2. Install the Teku client.
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./teku/helm -nteku
+    ```
+
+3. Check the configurations used.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nteku
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+We use `nimbus` as the namespace for the Nimbus client.
+
+On your master:
+
+1. Create the namespace.
+
+    ```bash
+    microk8s kubectl create namespace nimbus
+    ```
+
+2. Install the Nimbus client.
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./nimbus/helm -nnimbus
+    ```
+
+3. Check the configurations used.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nnimbus
+    ```
+
+{{< /toggle-panel >}}
+
 ### Check Client Status
+
+{{< toggle-panel name="Prysm" num="1" >}}
 
 1. Check the deployment status.
 
@@ -490,9 +762,94 @@ On your master:
     microk8s kubectl logs -f -nprysm -l app=validator-client-2
     ```
 
-### Upgrade the Prysm Version with Helm Chart
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+1. Check the deployment status.
+
+    ```bash
+    microk8s kubectl get pod -nlighthouse -w
+    ```
+
+    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in RUNNING status.
+
+2. Check the log of the beacon node.
+
+    ```bash
+    microk8s kubectl logs -f -nlighthouse -l app=beacon
+    ```
+
+3. Check the log of the first validator client.
+
+    ```bash
+    microk8s kubectl logs -f -nlighthouse -l app=validator-client-1
+    ```
+
+    To check other validator clients, change `-l app=<validator client name>` to other validator clients’ names specified in `values.yaml`, *e.g.* for checking the second validator client.
+
+    ```bash
+    microk8s kubectl logs -f -nlighthouse -l app=validator-client-2
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+1. Check the deployment status.
+
+    ```bash
+    microk8s kubectl get pod -nteku -w
+    ```
+
+    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in RUNNING status.
+
+2. Check the log of the beacon node.
+
+    ```bash
+    microk8s kubectl logs -f -nteku -l app=beacon
+    ```
+
+3. Check the log of the first validator client.
+
+    ```bash
+    microk8s kubectl logs -f -nteku -l app=validator-client-1
+    ```
+
+    To check other validator clients, change `-l app=<validator client name>` to other validator clients’ names specified in `values.yaml`, *e.g.* for checking the second validator client.
+
+    ```bash
+    microk8s kubectl logs -f -nteku -l app=validator-client-2
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+1. Check the deployment status.
+
+    ```bash
+    microk8s kubectl get pod -nnimbus -w
+    ```
+
+    This command will watch for changes. You can monitor it until the clients are all in RUNNING status.
+
+2. Check the log of the first nimbus client.
+
+    ```bash
+    microk8s kubectl logs -f -nnimbus -l app=nimbus-1
+    ```
+
+    To check other Nimbus clients, change `-l app=<nimbus client name>` to other Nimbus clients’ names specified in `values.yaml`, *e.g.* for checking the second Nimbus client.
+
+    ```bash
+    microk8s kubectl logs -f -nnimbus -l app=nimbus-2
+    ```
+
+{{< /toggle-panel >}}
+
+### Upgrade the Ethereum 2.0 Client Version with Helm Chart
 
 Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we should try to keep up with the new releases to get the up-to-date patches and features! We suggest using Helm for upgrading to leverage its releases and lifecycle management:
+
+{{< toggle-panel name="Prysm" num="1" >}}
 
 1. Check [Prysm Github release page](https://github.com/prysmaticlabs/prysm/releases) to get the latest release version.
 
@@ -510,11 +867,72 @@ Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we
     microk8s helm3 get manifest eth2xk8s -nprysm
     ```
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+1. Check [Lighthouse Github release page](https://github.com/sigp/lighthouse/releases) to get the latest release version.
+
+2. Modify the `image.version` in `values.yaml` to the latest version, *e.g.* `v1.3.0`, and save the change in `values.yaml`.
+
+3. Upgrade the client with the Helm upgrade command.
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./lighthouse/helm -nlighthouse
+    ```
+
+4. Check the configurations to see if it picks up the new version correctly.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nlighthouse
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+1. Check [Teku Github release page](https://github.com/ConsenSys/teku/releases) to get the latest release version.
+
+2. Modify the `image.version` in `values.yaml` to the latest version, *e.g.* `21.4.1`, and save the change in `values.yaml`.
+
+3. Upgrade the client with the Helm upgrade command.
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./teku/helm -nteku
+    ```
+
+4. Check the configurations to see if it picks up the new version correctly.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nteku
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+1. Check [Nimbus Github release page](https://github.com/status-im/nimbus-eth2/releases) to get the latest release version.
+
+2. Modify the `image.versionTag` in `values.yaml` to the latest version, *e.g.* `amd64-v1.2.1`, and save the change in `values.yaml`.
+
+3. Upgrade the client with the Helm upgrade command.
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./nimbus/helm -nnimbus
+    ```
+
+4. Check the configurations to see if it picks up the new version correctly.
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nnimbus
+    ```
+
+{{< /toggle-panel >}}
+
 5. Refer to [Check Client Status](#check-client-status) section to verify the client is running without issues.
 
 ### Roll Back the Release with Helm
 
-Rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. You can follow the steps below: 
+Rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. You can follow the steps below:
+
+{{< toggle-panel name="Prysm" num="1" >}}
 
 1. Check Helm release history and find a “good” release. Note the target revision number.
 
@@ -534,9 +952,62 @@ If the rollback involves schema changes, please refer to [Appendix: Roll Back th
 
 Sometimes, it’s not possible to downgrade to previous versions like described [here](https://docs.prylabs.network/docs/prysm-usage/staying-up-to-date/#downgrading-between-major-version-bumps). Please refer to the client team’s documentations for details before you downgrade the client.
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+1. Check Helm release history and find a “good” release. Note the target revision number.
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nlighthouse
+    ```
+
+2. If we want to roll back to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nlighthouse
+    ```
+
+3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+1. Check Helm release history and find a “good” release. Note the target revision number.
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nteku
+    ```
+
+2. If we want to roll back to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nteku
+    ```
+
+3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+1. Check Helm release history and find a “good” release. Note the target revision number.
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nnimbus
+    ```
+
+2. If we want to roll back to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nnimbus
+    ```
+
+3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
+
+{{< /toggle-panel >}}
+
 ## Conclusion
 
-Thank you for reading to the end of this guide! We hope this guide paves the way for staking with Kubernetes. We will continue to contribute more guides about staking with Kubernetes to the community. We are currently developing the Helm Chart and guides for other Ethereum 2.0 clients. Stay tuned!
+Thank you for reading to the end of this guide! We hope this guide paves the way for staking with Kubernetes. We will continue to contribute more guides about staking with Kubernetes to the community. Stay tuned!
 
 ## Feedback
 
@@ -558,21 +1029,74 @@ You can use [metrics server](https://github.com/kubernetes-sigs/metrics-server) 
     ```
 
 2. Run the `kubectl top` command, for example:
+{{< toggle-panel name="Prysm" num="1" >}}
 
-    ```bash
-    microk8s kubectl top pod -l app=beacon
-    microk8s kubectl top pod -l app=validator-client-1
-    ```
+```bash
+microk8s kubectl top pod -l app=beacon
+microk8s kubectl top pod -l app=validator-client-1
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+```bash
+microk8s kubectl top pod -l app=beacon
+microk8s kubectl top pod -l app=validator-client-1
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+```bash
+microk8s kubectl top pod -l app=beacon
+microk8s kubectl top pod -l app=validator-client-1
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+```bash
+microk8s kubectl top pod -l app=nimbus-1
+```
+
+{{< /toggle-panel >}}
 
 ### Uninstall Helm Chart
 
-If you want to stop and uninstall the Prysm client, you can uninstall the Helm Chart with the following command:
+If you want to stop and uninstall the Ethereum 2.0 client, you can uninstall the Helm Chart with the following command:
+
+{{< toggle-panel name="Prysm" num="1" >}}
 
 ```bash
 microk8s helm3 uninstall eth2xk8s -nprysm
 ```
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nlighthouse
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nteku
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nnimbus
+```
+
+{{< /toggle-panel >}}
+
 ### Roll Back the Release with Helm (Schema Changes)
+
+{{< toggle-panel name="Prysm" num="1" >}}
 
 Take [Prysm v1.3.0 release](https://github.com/prysmaticlabs/prysm/releases/tag/v1.3.0) as an example. If you decide to roll back to v1.2.x after upgrading to v1.3.0, you’ll need to run a script first to reverse the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
 
@@ -616,3 +1140,11 @@ Hence, we can take advantage of Kubernetes to help us temporarily scale down the
     ```bash
     microk8s kubectl get pod -nprysm -w
     ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+{{< /toggle-panel >}}

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -561,7 +561,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
     - **image.versionTag**: Prysm client version.
     - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
-    - **beacon.web3Provider** and **beacon.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
+    - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1**
       - **.dataVolumePath**: The path to the data directory on the NFS for the validator client.
       - **.walletVolumePath**: The path to the data directory on the NFS for the wallet.
@@ -592,7 +592,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
     - **image.versionTag**: Teku client version.
     - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
-    - **beacon.eth1Endpoint**: Ethereum 1.0 node endpoint.
+    - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1**
       - **.dataVolumePath**: The path to the data directory on the NFS for the validator client.
       - **.validatorKeysVolumePath**: The path to the data directory on the NFS for the validator keys.
@@ -609,7 +609,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
     - **image.versionTag**: Nimbus client version.
     - **nimbus.clients.client1**
-      - **.web3Provider** and **.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
+      - **.eth1Endpoints**: Ethereum 1.0 node endpoints.
       - **.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
       - **.validatorsVolumePath**: The path to the data directory on the NFS for the validator keystores.
       - **.secretsVolumePath**: The path to the data directory on the NFS for the validator keystore passwords.

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -29,26 +29,7 @@ We want to thank Ethereum Foundation for supporting this project via the [Eth2 S
 
 In this step-by-step guide, we run one beacon node with multiple validator clients in a Kuberenetes cluster for Ethereum 2.0 staking. We are using:
 
-- {{< toggle-panel name="Prysm" active=true >}}
-
-[Prysm](https://github.com/prysmaticlabs/prysm) as the Ethereum 2.0 Client.
-
-{{< /toggle-panel >}}
-{{< toggle-panel name="Lighthouse" >}}
-
-[Lighthouse](https://github.com/sigp/lighthouse) as the Ethereum 2.0 Client.
-
-{{< /toggle-panel >}}
-{{< toggle-panel name="Teku" >}}
-
-[Teku](https://github.com/ConsenSys/teku) as the Ethereum 2.0 Client.
-
-{{< /toggle-panel >}}
-{{< toggle-panel name="Nimbus" >}}
-
-[Nimbus](https://github.com/status-im/nimbus-eth2) as the Ethereum 2.0 Client.
-
-{{< /toggle-panel >}}
+- Ethereum 2.0 Client ([Prysm](https://github.com/prysmaticlabs/prysm), [Lighthouse](https://github.com/sigp/lighthouse), [Teku](https://github.com/ConsenSys/teku) or [Nimbus](https://github.com/status-im/nimbus-eth2))
 - [MicroK8s](https://microk8s.io/) as the Kubernertes destribution ([installation guide](https://microk8s.io/docs)).
 - [Helm 3](https://helm.sh/) to manage packages and releases.
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) to run commands against Kubernetes clusters.

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -556,7 +556,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
 
 We understand it is not trivial to learn Kubernetes and create manifests or Helm Charts for staking from scratch, so we’ve already done this for you to help you bootstrap! We uploaded all the manifests in our Github repository [eth2xk8s](https://github.com/lumostone/eth2xk8s).
 
-We use Helm to manage packages and releases in this guide. You can also use Kubernetes manifests directly. Please see [Testing manifests with Prysm and hostPath](https://github.com/lumostone/eth2xk8s/blob/master/prysm/host-path/README.md) and [Testing manifests with Prysm and NFS](https://github.com/lumostone/eth2xk8s/blob/master/prysm/nfs/README.md) for details.
+We use Helm to manage packages and releases in this guide. You can also use Kubernetes manifests directly. Please see [Testing manifests with hostPath](https://github.com/lumostone/eth2xk8s/blob/master/testing-with-host-path.md) and [Testing manifests with NFS](https://github.com/lumostone/eth2xk8s/blob/master/testing-with-nfs.md) for details.
 
 1. Clone this repo.
 
@@ -566,7 +566,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
 
 {{< toggle-panel name="Prysm" num="1" >}}
 
-2. Change values in [./prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml).
+2. Change values in [prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml).
 
     We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
     - **nfs.serverIp**: NFS server IP address.

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -1,9 +1,11 @@
 ---
-title: "Guide to Ethereum 2.0 Staking with Kubernetes and Prysm"
+title: "Guide to Ethereum 2.0 Staking with Kubernetes"
 date: 2021-04-19T23:53:09Z
-draft: false
+draft: true
 tags: ["ethereum", "kubernetes", "tutorial"]
 ---
+
+{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" >}}
 
 ## Why Stake with Kubernetes? 
 As stakers, we all want to minimize downtime and the risk of being slashed. 

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -115,8 +115,8 @@ NFS:
 
 ## Prerequisites
 
-- You have funded your validators and have generated validator keys. If you need guidance, we recommend [Somer Esat’s guide](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3).
-- Ethereum 1.0 “Goerli” node: [Somer Esat’s guide](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3) also covers steps for building the Ethereum 1.0 node. You can also choose a third-party provider such as [Infura](https://infura.io/) or [Alchemy](https://alchemyapi.io/).
+- You have funded your validators and have generated validator keys. If you need guidance, we recommend [Somer Esat’s guide](https://medium.com/search?q=someresat%20Guide%20to%20Staking).
+- Ethereum 1.0 “Goerli” node: [Somer Esat’s guide](https://medium.com/search?q=someresat%20Guide%20to%20Staking) also covers steps for building the Ethereum 1.0 node. You can also choose a third-party provider such as [Infura](https://infura.io/) or [Alchemy](https://alchemyapi.io/).
 - Planning your private network, firewall, and port forwarding. We have put our network configuration in the [Walkthrough](#overview) for your reference.
 - You have installed Ubuntu Server 20.04.2 LTS (x64) on all the servers and have assigned static IPs.
 
@@ -572,7 +572,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **nfs.serverIp**: NFS server IP address.
     - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
-    - **image.version**: Prysm client version.
+    - **image.versionTag**: Prysm client version.
     - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
     - **beacon.web3Provider** and **beacon.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1**
@@ -589,7 +589,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **nfs.serverIp**: NFS server IP address.
     - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
-    - **image.version**: Lighthouse client version.
+    - **image.versionTag**: Lighthouse client version.
     - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
     - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1.dataVolumePath**: The path to the data directory on the NFS for the validator client.
@@ -603,7 +603,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **nfs.serverIp**: NFS server IP address.
     - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
-    - **image.version**: Teku client version.
+    - **image.versionTag**: Teku client version.
     - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
     - **beacon.eth1Endpoint**: Ethereum 1.0 node endpoint.
     - **validatorClients.validatorClient1**
@@ -631,9 +631,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
 
 ### Install Ethereum 2.0 Client via Helm Chart
 
-Helm uses [releases](https://helm.sh/docs/glossary/#release) to track each of the chart installations. In this guide, we specify our release name as `eth2xk8s`, you can change it to anything you prefer.
-
-Kubernetes has the concept of [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) to define scopes for names and isolate accesses between resources.
+Helm uses [releases](https://helm.sh/docs/glossary/#release) to track each of the chart installations. In this guide, we specify our release name as `eth2xk8s`, you can change it to anything you prefer. We'll install the Helm Chart in a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/), which defines scopes for names and isolates accesses between resources.
 
 {{< toggle-panel name="Prysm" num="1" >}}
 We use `prysm` as the namespace for the Prysm client.
@@ -853,7 +851,7 @@ Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we
 
 1. Check [Prysm Github release page](https://github.com/prysmaticlabs/prysm/releases) to get the latest release version.
 
-2. Modify the `image.version` in `values.yaml` to the latest version, *e.g.* `v1.3.4`, and save the change in `values.yaml`.
+2. Modify the `image.versionTag` in `values.yaml` to the latest version, *e.g.* `v1.3.4`, and save the change in `values.yaml`.
 
 3. Upgrade the client with the Helm upgrade command.
 
@@ -872,7 +870,7 @@ Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we
 
 1. Check [Lighthouse Github release page](https://github.com/sigp/lighthouse/releases) to get the latest release version.
 
-2. Modify the `image.version` in `values.yaml` to the latest version, *e.g.* `v1.3.0`, and save the change in `values.yaml`.
+2. Modify the `image.versionTag` in `values.yaml` to the latest version, *e.g.* `v1.3.0`, and save the change in `values.yaml`.
 
 3. Upgrade the client with the Helm upgrade command.
 
@@ -891,7 +889,7 @@ Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we
 
 1. Check [Teku Github release page](https://github.com/ConsenSys/teku/releases) to get the latest release version.
 
-2. Modify the `image.version` in `values.yaml` to the latest version, *e.g.* `21.4.1`, and save the change in `values.yaml`.
+2. Modify the `image.versionTag` in `values.yaml` to the latest version, *e.g.* `21.4.1`, and save the change in `values.yaml`.
 
 3. Upgrade the client with the Helm upgrade command.
 
@@ -930,7 +928,7 @@ Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we
 
 ### Roll Back the Release with Helm
 
-Rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. You can follow the steps below:
+Rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. If the rollback involves schema changes, please refer to [Appendix: Roll Back the Release with Helm (Schema Changes)](#roll-back-the-release-with-helm-schema-changes) for details. Otherwise, you can follow the steps below:
 
 {{< toggle-panel name="Prysm" num="1" >}}
 
@@ -947,8 +945,6 @@ Rolling back with Helm is usually as straightforward as upgrading when there’s
     ```
 
 3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
-
-If the rollback involves schema changes, please refer to [Appendix: Roll Back the Release with Helm (Schema Changes)](#roll-back-the-release-with-helm-schema-changes) for details.
 
 Sometimes, it’s not possible to downgrade to previous versions like described [here](https://docs.prylabs.network/docs/prysm-usage/staying-up-to-date/#downgrading-between-major-version-bumps). Please refer to the client team’s documentations for details before you downgrade the client.
 
@@ -969,6 +965,8 @@ Sometimes, it’s not possible to downgrade to previous versions like described 
 
 3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
 
+Sometimes, it’s not possible to downgrade to previous versions. Please refer to the client team’s documentations for details before you downgrade the client.
+
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
 
@@ -986,6 +984,8 @@ Sometimes, it’s not possible to downgrade to previous versions like described 
 
 3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
 
+Sometimes, it’s not possible to downgrade to previous versions. Please refer to the client team’s documentations for details before you downgrade the client.
+
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
 
@@ -1002,6 +1002,8 @@ Sometimes, it’s not possible to downgrade to previous versions like described 
     ```
 
 3. Check the configurations used and refer to the [Check Client Status](#check-client-status) section to verify the client is running without issues.
+
+Sometimes, it’s not possible to downgrade to previous versions. Please refer to the client team’s documentations for details before you downgrade the client.
 
 {{< /toggle-panel >}}
 
@@ -1143,8 +1145,133 @@ Hence, we can take advantage of Kubernetes to help us temporarily scale down the
 
 {{< /toggle-panel >}}
 {{< toggle-panel name="Lighthouse" >}}
+
+If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reserve the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
+
+Hence, we can take advantage of Kubernetes to help us temporarily scale down the pods and then to run the reverse migration tool (if any) before rolling back.
+
+1. Before rolling back the release, scale down the target deployment, *e.g*. scale down beacon node
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nlighthouse --replicas=0
+    ```
+
+    or scale down validator-client-1 if the schema changes only affect validators
+
+    ```bash
+    microk8s kubectl scale deployments/validator-client-1 -nlighthouse --replicas=0
+    ```
+
+2. Confirm that the pod(s) are terminated.
+
+    ```bash
+    microk8s kubectl get pod -nlighthouse -w
+    ```
+
+3. Reverse database migration.
+
+4. Roll back the release to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nlighthouse
+    ```
+
+5. Scale up the deployment.
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nlighthouse --replicas=1
+    microk8s kubectl scale deployments/validator-client-1 -nlighthouse --replicas=1
+    ```
+
+6. Confirm that the pod(s) are running.
+
+    ```bash
+    microk8s kubectl get pod -nlighthouse -w
+    ```
+
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
+
+If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reserve the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
+
+Hence, we can take advantage of Kubernetes to help us temporarily scale down the pods and then to run the reverse migration tool (if any) before rolling back.
+
+1. Before rolling back the release, scale down the target deployment, *e.g*. scale down beacon node
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nteku --replicas=0
+    ```
+
+    or scale down validator-client-1 if the schema changes only affect validators
+
+    ```bash
+    microk8s kubectl scale deployments/validator-client-1 -nteku --replicas=0
+    ```
+
+2. Confirm that the pod(s) are terminated.
+
+    ```bash
+    microk8s kubectl get pod -nteku -w
+    ```
+
+3. Reverse database migration.
+
+4. Roll back the release to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nteku
+    ```
+
+5. Scale up the deployment.
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nteku --replicas=1
+    microk8s kubectl scale deployments/validator-client-1 -nteku --replicas=1
+    ```
+
+6. Confirm that the pod(s) are running.
+
+    ```bash
+    microk8s kubectl get pod -nteku -w
+    ```
+
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
+
+If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reserve the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
+
+Hence, we can take advantage of Kubernetes to help us temporarily scale down the pods and then to run the reverse migration tool (if any) before rolling back.
+
+1. Before rolling back the release, scale down the target deployment, *e.g*. scale down beacon node
+
+    ```bash
+    microk8s kubectl scale deployments/nimbus-1 -nnimbus --replicas=0
+    ```
+
+2. Confirm that the pod(s) are terminated.
+
+    ```bash
+    microk8s kubectl get pod -nnimbus -w
+    ```
+
+3. Reverse database migration.
+
+4. Roll back the release to revision 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nnimbus
+    ```
+
+5. Scale up the deployment.
+
+    ```bash
+    microk8s kubectl scale deployments/nimbus-1 -nnimbus --replicas=1
+    ```
+
+6. Confirm that the pod(s) are running.
+
+    ```bash
+    microk8s kubectl get pod -nnimbus -w
+    ```
+
 {{< /toggle-panel >}}

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -491,7 +491,7 @@ Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/main
 
 Please refer to [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/validator-import-launchpad.html) about how to import your validator accounts into Lighthouse or follow the instructions below.
 
-1. Please follow [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/installation-binaries.html) to download Lighthouse pre-built binary.
+1. Please follow [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/installation-binaries.html) to download the pre-built binary.
 
 2. Execute the binary with `--directory=<path/to/validator-keys>` (Remember to replace it with the directory you place the keys). We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys and `/data/lighthouse/validator-client-1` for the data directory of the validator client.
 
@@ -519,7 +519,7 @@ Please refer to [Teku's documentation](https://docs.teku.consensys.net/en/latest
 
 Please refer to [Nimbus's documentation](https://nimbus.guide/keys.html) about how to import your validator accounts into Nimbus or follow the instructions below.
 
-1. Please follow [Nimbus's documentation](https://nimbus.guide/binaries.html) to download Nimbus pre-built binary.
+1. Please follow [Nimbus's documentation](https://nimbus.guide/binaries.html) to download the pre-built binary.
 
 2. Execute the binary with the directory you place the keys. We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys and `/data/nimbus-1` for the data directory of the Nimbus client.
 
@@ -1133,7 +1133,7 @@ Hence, we can take advantage of Kubernetes to help us temporarily scale down the
 {{< /toggle-panel >}}
 {{< toggle-panel name="Lighthouse" >}}
 
-If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reserve the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
+If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reverse the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
 
 Hence, we can take advantage of Kubernetes to help us temporarily scale down the pods and then to run the reverse migration tool (if any) before rolling back.
 
@@ -1179,7 +1179,7 @@ Hence, we can take advantage of Kubernetes to help us temporarily scale down the
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
 
-If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reserve the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
+If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reverse the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
 
 Hence, we can take advantage of Kubernetes to help us temporarily scale down the pods and then to run the reverse migration tool (if any) before rolling back.
 
@@ -1225,7 +1225,7 @@ Hence, we can take advantage of Kubernetes to help us temporarily scale down the
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
 
-If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reserve the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
+If you decide to downgrade the client version but there's schema change due to version upgrade, you might be able to use tools provided by the client team to reverse the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
 
 Hence, we can take advantage of Kubernetes to help us temporarily scale down the pods and then to run the reverse migration tool (if any) before rolling back.
 

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -3,11 +3,13 @@ title: "Guide to Ethereum 2.0 Staking with Kubernetes"
 date: 2021-05-07T23:53:09Z
 draft: true
 tags: ["ethereum", "kubernetes", "tutorial"]
+aliases: 
+    - /en/eth2-staking-with-k8s-prysm/
 ---
 
 > On May 10, 2020, this guide has been updated to include Lighthouse, Teku and Nimbus clients along with Prysm, the Ethereum 2.0 client we started with.
 
-{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" >}}
+{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" active="toggle1" >}}
 
 ## Why Stake with Kubernetes?
 
@@ -29,7 +31,7 @@ We want to thank Ethereum Foundation for supporting this project via the [Eth2 S
 
 In this step-by-step guide, we run one beacon node with multiple validator clients in a Kuberenetes cluster for Ethereum 2.0 staking. We are using:
 
-- {{< toggle-panel name="Prysm" num="1" >}}
+- {{< toggle-panel name="Prysm" active=true >}}
 
 [Prysm](https://github.com/prysmaticlabs/prysm) as the Ethereum 2.0 Client.
 
@@ -253,7 +255,7 @@ Perform step 1-3 on all the machines:
     ```
 
 6. On the master and worker machines, add the rules for beacon node:
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 ```bash
 sudo ufw allow 12000/udp
@@ -383,7 +385,7 @@ On the machine you plan to run NFS:
     sudo systemctl start nfs-kernel-server.service
     ```
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 2. Create directories for the beacon node, validator clients, and wallets.
 
@@ -482,7 +484,7 @@ On the machine you plan to run NFS:
 ### Prepare Validator Wallets
 
 Let’s get back to the NFS server to import the validator keys created with [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli). Before proceeding, please have your validator keys placed on your NFS machine.
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm) about how to import your validator accounts into Prysm.
 
@@ -564,7 +566,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     git clone https://github.com/lumostone/eth2xk8s.git
     ```
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 2. Change values in [prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml).
 
@@ -633,7 +635,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
 
 Helm uses [releases](https://helm.sh/docs/glossary/#release) to track each of the chart installations. In this guide, we specify our release name as `eth2xk8s`, you can change it to anything you prefer. We'll install the Helm Chart in a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/), which defines scopes for names and isolates accesses between resources.
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 We use `prysm` as the namespace for the Prysm client.
 
 On your master:
@@ -732,7 +734,7 @@ On your master:
 
 ### Check Client Status
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 1. Check the deployment status.
 
@@ -847,7 +849,7 @@ On your master:
 
 Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we should try to keep up with the new releases to get the up-to-date patches and features! We suggest using Helm for upgrading to leverage its releases and lifecycle management:
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 1. Check [Prysm Github release page](https://github.com/prysmaticlabs/prysm/releases) to get the latest release version.
 
@@ -930,7 +932,7 @@ Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we
 
 Rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. If the rollback involves schema changes, please refer to [Appendix: Roll Back the Release with Helm (Schema Changes)](#roll-back-the-release-with-helm-schema-changes) for details. Otherwise, you can follow the steps below:
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 1. Check Helm release history and find a “good” release. Note the target revision number.
 
@@ -1031,7 +1033,7 @@ You can use [metrics server](https://github.com/kubernetes-sigs/metrics-server) 
     ```
 
 2. Run the `kubectl top` command, for example:
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 ```bash
 microk8s kubectl top pod -l app=beacon
@@ -1067,7 +1069,7 @@ microk8s kubectl top pod -l app=nimbus-1
 
 If you want to stop and uninstall the Ethereum 2.0 client, you can uninstall the Helm Chart with the following command:
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 ```bash
 microk8s helm3 uninstall eth2xk8s -nprysm
@@ -1098,7 +1100,7 @@ microk8s helm3 uninstall eth2xk8s -nnimbus
 
 ### Roll Back the Release with Helm (Schema Changes)
 
-{{< toggle-panel name="Prysm" num="1" >}}
+{{< toggle-panel name="Prysm" active=true >}}
 
 Take [Prysm v1.3.0 release](https://github.com/prysmaticlabs/prysm/releases/tag/v1.3.0) as an example. If you decide to roll back to v1.2.x after upgrading to v1.3.0, you’ll need to run a script first to reverse the database migration. If we use instructions in [Roll Back the Release with Helm](#roll-back-the-release-with-helm) directly, the pods will restart right after the version is changed by Helm and the client might not run due to the unmatched schema.
 

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -27,7 +27,7 @@ We want to thank Ethereum Foundation for supporting this project via the [Eth2 S
 
 ## Technologies
 
-In this step-by-step guide, we run one beacon node with multiple validator clients in a Kuberenetes cluster for Ethereum 2.0 staking. We are using:
+In this step-by-step guide, we run multiple Ethereum 2.0 clients in a Kuberenetes cluster for staking. We are using:
 
 - Ethereum 2.0 Client ([Prysm](https://github.com/prysmaticlabs/prysm), [Lighthouse](https://github.com/sigp/lighthouse), [Teku](https://github.com/ConsenSys/teku) or [Nimbus](https://github.com/status-im/nimbus-eth2))
 - [MicroK8s](https://microk8s.io/) as the Kubernertes destribution ([installation guide](https://microk8s.io/docs)).

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -7,9 +7,7 @@ aliases:
     - /en/eth2-staking-with-k8s-prysm/
 ---
 
-> On May 10, 2020, this guide has been updated to include Lighthouse, Teku and Nimbus clients along with Prysm, the Ethereum 2.0 client we started with.
-
-{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" active="toggle1" >}}
+> On May 10, 2021, this guide has been updated to include Lighthouse, Teku and Nimbus clients along with Prysm, the Ethereum 2.0 client we started with.
 
 ## Why Stake with Kubernetes?
 
@@ -123,6 +121,11 @@ NFS:
 - You have installed Ubuntu Server 20.04.2 LTS (x64) on all the servers and have assigned static IPs.
 
 ## Walkthrough
+
+### Choose Your Ethereum 2.0 Client
+
+The content of the following guide will be changed based on your client selection. Please choose the one your prefer before continue reading:
+{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" active="toggle1" >}}
 
 ### Overview
 
@@ -419,7 +422,7 @@ On the machine you plan to run NFS:
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
 
-1. Create directories for the beacon node, validator clients, validator keys and key passwords.
+2. Create directories for the beacon node, validator clients, validator keys and key passwords.
 
     ```bash
     sudo mkdir -p /data/teku/beacon
@@ -448,7 +451,7 @@ On the machine you plan to run NFS:
 
 {{< /toggle-panel >}}
 
-1. Configure and export NFS storage.
+3. Configure and export NFS storage.
 
     ```bash
     sudo nano /etc/exports
@@ -475,7 +478,7 @@ On the machine you plan to run NFS:
     sudo exportfs -a
     ```
 
-2. On your master and worker nodes, enable NFS support by installing `nfs-common`:
+4. On your master and worker nodes, enable NFS support by installing `nfs-common`:
 
     ```bash
     sudo apt install nfs-common
@@ -486,7 +489,7 @@ On the machine you plan to run NFS:
 Let’s get back to the NFS server to import the validator keys created with [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli). Before proceeding, please have your validator keys placed on your NFS machine.
 {{< toggle-panel name="Prysm" active=true >}}
 
-Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm) about how to import your validator accounts into Prysm.
+Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm) about how to import your validator accounts into Prysm or follow the instructions below.
 
 1. Please follow [Prysm’s documentation](https://docs.prylabs.network/docs/install/install-with-script/#downloading-the-prysm-startup-script) to download Prysm startup script.
 
@@ -505,7 +508,7 @@ Please refer to [Prysm’s documentation](https://docs.prylabs.network/docs/main
 {{< /toggle-panel >}}
 {{< toggle-panel name="Lighthouse" >}}
 
-Please refer to [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/validator-import-launchpad.html) about how to import your validator accounts into Lighthouse.
+Please refer to [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/validator-import-launchpad.html) about how to import your validator accounts into Lighthouse or follow the instructions below.
 
 1. Please follow [Lighthouse's documentation](https://lighthouse-book.sigmaprime.io/installation-binaries.html) to download Lighthouse pre-built binary.
 
@@ -520,24 +523,24 @@ Please refer to [Lighthouse's documentation](https://lighthouse-book.sigmaprime.
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
 
-Please refer to [Teku's documentation](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#generate-the-validators-and-send-the-deposits) about how to import your validator accounts into Teku.
+Please refer to [Teku's documentation](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#generate-the-validators-and-send-the-deposits) about how to import your validator accounts into Teku or follow the instructions below.
 
-1. Copy validator keys into the target folder for keys. Assume our keys generated with `eth2.0-deposit-cli` is under `$HOME/eth2.0-deposit-cli/validator_keys` and our target folder for keys is /data/teku/validator-keys-1
+1. Copy validator keys into the target folder for keys. Assume our keys generated with `eth2.0-deposit-cli` is under `$HOME/eth2.0-deposit-cli/validator_keys` and our target folder for keys is `/data/teku/validator-keys-1`
 
     ```bash
     sudo cp  $HOME/eth2.0-deposit-cli/validator_keys/* /data/teku/validator-keys-1/
     ```
 
-2. Create one password txt file for each corresponding key in the target folder for key passwords, `/data/teku/validator-key-passwords-1`. For example, if there's a keystore named keystore-m_123.json, you'll need to create a file named keystore-m_123.txt and store the keystore's password in it.
+2. Create one password txt file for each corresponding key in the target folder for key passwords (assume it's `/data/teku/validator-key-passwords-1`). For example, if there's a keystore named `keystore-m_123.json`, you'll need to create a file named `keystore-m_123.txt` and store the keystore's password in it.
 
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
 
-Please refer to [Nimbus's documentation](https://nimbus.guide/keys.html) about how to import your validator accounts into Nimbus.
+Please refer to [Nimbus's documentation](https://nimbus.guide/keys.html) about how to import your validator accounts into Nimbus or follow the instructions below.
 
 1. Please follow [Nimbus's documentation](https://nimbus.guide/binaries.html) to download Nimbus pre-built binary.
 
-2. Execute the binary with `<path/to/validator-keys>` (Remember to replace it with the directory you place the keys). We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys and `/data/nimbus-1` for the data directory of the Nimbus client.
+2. Execute the binary with the directory you place the keys. We use `$HOME/eth2.0-deposit-cli/validator_keys` as the example path to the validator keys and `/data/nimbus-1` for the data directory of the Nimbus client.
 
     ```bash
     sudo nimbus_beacon_node deposits import --data-dir=/data/nimbus-1 $HOME/eth2.0-deposit-cli/validator_keys
@@ -546,6 +549,7 @@ Please refer to [Nimbus's documentation](https://nimbus.guide/keys.html) about h
 3. Enter the password you used to create the validator keys with `eth2.0-deposit-cli`. If you enter it correctly, the keys will be imported.
 
 {{< /toggle-panel >}}
+
 ### Change the owner of the data folder
 
 On the NFS machine, let’s change the directory owners so later these directories can be mounted by Kubernetes as the storage volumes for the pods running the beacon node and the validator clients. 
@@ -585,7 +589,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
 {{< /toggle-panel >}}
 {{< toggle-panel name="Lighthouse" >}}
 
-1. Change values in [./lighthouse/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/lighthouse/helm/values.yaml).
+2. Change values in [lighthouse/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/lighthouse/helm/values.yaml).
 
     We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
     - **nfs.serverIp**: NFS server IP address.
@@ -599,7 +603,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
 
-1. Change values in [./teku/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/teku/helm/values.yaml).
+2. Change values in [teku/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/teku/helm/values.yaml).
 
     We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
     - **nfs.serverIp**: NFS server IP address.
@@ -616,7 +620,7 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
 
-1. Change values in [./nimbus/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/nimbus/helm/values.yaml).
+2. Change values in [nimbus/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/nimbus/helm/values.yaml).
 
     We recommend checking each field in `values.yaml` to determine the desired configuration. Fields that need to be changed or verified before installing the chart are the following ones:
     - **nfs.serverIp**: NFS server IP address.
@@ -742,7 +746,7 @@ On your master:
     microk8s kubectl get pod -nprysm -w
     ```
 
-    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in RUNNING status.
+    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in `Running` status.
 
 2. Check the log of the beacon node.
 
@@ -771,7 +775,7 @@ On your master:
     microk8s kubectl get pod -nlighthouse -w
     ```
 
-    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in RUNNING status.
+    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in `Running` status.
 
 2. Check the log of the beacon node.
 
@@ -800,7 +804,7 @@ On your master:
     microk8s kubectl get pod -nteku -w
     ```
 
-    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in RUNNING status.
+    This command will watch for changes. You can monitor it until the beacon node and validator clients are all in `Running` status.
 
 2. Check the log of the beacon node.
 
@@ -829,9 +833,9 @@ On your master:
     microk8s kubectl get pod -nnimbus -w
     ```
 
-    This command will watch for changes. You can monitor it until the clients are all in RUNNING status.
+    This command will watch for changes. You can monitor it until the clients are all in `Running` status.
 
-2. Check the log of the first nimbus client.
+2. Check the log of the first Nimbus client.
 
     ```bash
     microk8s kubectl logs -f -nnimbus -l app=nimbus-1
@@ -930,7 +934,7 @@ Ethereum 2.0 client teams work hard to push new versions frequently. Ideally, we
 
 ### Roll Back the Release with Helm
 
-Rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. If the rollback involves schema changes, please refer to [Appendix: Roll Back the Release with Helm (Schema Changes)](#roll-back-the-release-with-helm-schema-changes) for details. Otherwise, you can follow the steps below:
+If the rollback involves schema changes, please refer to [Appendix: Roll Back the Release with Helm (Schema Changes)](#roll-back-the-release-with-helm-schema-changes) for details. Otherwise, rolling back with Helm is usually as straightforward as upgrading when there’s no database schema changes involved. You can follow the steps below:
 
 {{< toggle-panel name="Prysm" active=true >}}
 

--- a/content/en/posts/eth2-staking-with-k8s.md
+++ b/content/en/posts/eth2-staking-with-k8s.md
@@ -560,11 +560,11 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
     - **image.versionTag**: Prysm client version.
-    - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
+    - **beacon.dataDirPath**: The path to the data directory on the NFS for the beacon node.
     - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1**
-      - **.dataVolumePath**: The path to the data directory on the NFS for the validator client.
-      - **.walletVolumePath**: The path to the data directory on the NFS for the wallet.
+      - **.dataDirPath**: The path to the data directory on the NFS for the validator client.
+      - **.walletDirPath**: The path to the wallet directory on the NFS for the validator client.
       - **.walletPassword**: The wallet password.
 
 {{< /toggle-panel >}}
@@ -577,9 +577,9 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
     - **image.versionTag**: Lighthouse client version.
-    - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
+    - **beacon.dataDirPath**: The path to the data directory on the NFS for the beacon node.
     - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
-    - **validatorClients.validatorClient1.dataVolumePath**: The path to the data directory on the NFS for the validator client.
+    - **validatorClients.validatorClient1.dataDirPath**: The path to the data directory on the NFS for the validator client.
 
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
@@ -591,12 +591,12 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **securityContext.runAsUser**: The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
     - **securityContext.runAsGroup**: The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume. We use the group ID to grant limited file access to the processes so it won't use the root group directly.
     - **image.versionTag**: Teku client version.
-    - **beacon.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
+    - **beacon.dataDirPath**: The path to the data directory on the NFS for the beacon node.
     - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1**
-      - **.dataVolumePath**: The path to the data directory on the NFS for the validator client.
-      - **.validatorKeysVolumePath**: The path to the data directory on the NFS for the validator keys.
-      - **.validatorKeyPasswordsVolumePath**: The path to the data directory on the NFS for the validator key passwords.
+      - **.dataDirPath**: The path to the data directory on the NFS for the validator client.
+      - **.validatorKeysDirPath**: The path to the data directory on the NFS for the validator keys.
+      - **.validatorKeyPasswordsDirPath**: The path to the data directory on the NFS for the validator key passwords.
 
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
@@ -610,9 +610,9 @@ We use Helm to manage packages and releases in this guide. You can also use Kube
     - **image.versionTag**: Nimbus client version.
     - **nimbus.clients.client1**
       - **.eth1Endpoints**: Ethereum 1.0 node endpoints.
-      - **.dataVolumePath**: The path to the data directory on the NFS for the beacon node.
-      - **.validatorsVolumePath**: The path to the data directory on the NFS for the validator keystores.
-      - **.secretsVolumePath**: The path to the data directory on the NFS for the validator keystore passwords.
+      - **.dataDirPath**: The path to the data directory on the NFS for the beacon node.
+      - **.validatorsDirPath**: The path to the data directory on the NFS for the validator keystores.
+      - **.secretsDirPath**: The path to the data directory on the NFS for the validator keystore passwords.
 
 {{< /toggle-panel >}}
 

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -7,28 +7,48 @@ aliases:
     - /zh-tw/eth2-staking-with-k8s-prysm/
 ---
 
-{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" active="toggle1" >}}
+> 2021/05/10: 在這篇教學裡，除了原本包含的 Prysm 以外，我們也加上了 Lighthouse, Teku 以及 Nimbus 的教學！
 
 ## 為什麼使用 Kubernetes 作 staking？
+
 作為 staker，我們常擔憂 validator 是否會突然停機，或是被區塊鏈上其他節點認作是壞成員而遭到驅逐（slashing）。如何最小化停機時間和降低被驅逐的風險，成為了一個 staker 時常考慮的問題。
 
 停機的原因百百種，可能是系統需要執行更新，軟體有問題，網路斷線，硬碟罷工等等。我們都希望可以時時監控，一旦有問題發生就立刻處理，但問題可大可小，不是每一次都能很快修復，除非是全職 staking，不然一般也沒辦法二十四小時監控處理。面對這種有高可用性的需求情境時，我們很自然地會想到 redundancy，如果怕一台機器停工，那我就再多準備幾台機器，一旦有問題就可以把系統轉移到健康的機器。
 
 然而，我們常在論壇上看到 staker 們彼此警告「redundancy 可能會導致 slashing」，因為在轉移系統的過程，可能會因為手動操作疏失，不小心讓多個 validator 用戶端同時使用同一個 validator 金鑰，或是 slashing protection database 移轉時資料毀損，新的 validator 太快上線，又重新上傳了已經驗證過的區塊等等，這些都會讓 validator 面臨 slashing 的懲罰。當我們有多個 validator ，又同時想要追求 redundancy、高可用性，這些維運複雜度就會跟著上升，追求 redundancy 反而產生更多 slashing 的風險。
 
-**我們有可能降低 slashing 風險跟維運複雜度，同時又能擁抱 redundancy 帶給我們的好處嗎？** 有的！我們認為 [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) 可以幫我們做到這件事，運用 Kubernetes 管理 validator 的生命週期，自動化容錯移轉（failover），在軟體更新時，只需要更改版本號，Kubernetes 就可以幫我們安全升級，今天硬體要更新，要手動移轉 validator 時，僅用一個指令便能完成（例如：`kubectl drain node`）。 
+**我們有可能降低 slashing 風險跟維運複雜度，同時又能擁抱 redundancy 帶給我們的好處嗎？** 有的！我們認為 [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) 可以幫我們做到這件事，運用 Kubernetes 管理 validator 的生命週期，自動化容錯移轉（failover），在軟體更新時，只需要更改版本號，Kubernetes 就可以幫我們安全升級，今天硬體要更新，要手動移轉 validator 時，僅用一個指令便能完成（例如：`kubectl drain node`）。
 
 我們希望這篇教學文章可以作為以太坊 2.0 staker community 的墊腳石，讓 stakers 可以利用 Kubernetes 建立一個有擴充性又有 redundancy 的基礎架構，一起輕鬆 staking！
 
 ## 感謝
-謝謝以太坊基金會以 [Eth2 Staking Community Grants](https://blog.ethereum.org/2021/02/09/esp-staking-community-grantee-announcement/) 支持這個專案，能夠對 staker community 貢獻是我們的榮幸！
 
+謝謝以太坊基金會以 [Eth2 Staking Community Grants](https://blog.ethereum.org/2021/02/09/esp-staking-community-grantee-announcement/) 支持這個專案，能夠對 staker community 貢獻是我們的榮幸！
 
 ## 使用工具
 
 這份教學將示範如何在一個 Kubernetes 叢集上維運一個以太坊 2.0 beacon 用戶端和多個 validator 用戶端， 以下是我們使用的工具：
 
-- [Prysm](https://github.com/prysmaticlabs/prysm) 以太坊 2.0 用戶端
+- {{< toggle-panel name="Prysm" active=true >}}
+
+[Prysm](https://github.com/prysmaticlabs/prysm) 以太坊 2.0 用戶端
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+[Lighthouse](https://github.com/sigp/lighthouse) 以太坊 2.0 用戶端
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+[Teku](https://github.com/ConsenSys/teku) 以太坊 2.0 用戶端
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+[Nimbus](https://github.com/status-im/nimbus-eth2) 以太坊 2.0 用戶端
+
+{{< /toggle-panel >}}
 - [MicroK8s](https://microk8s.io/) 輕量的 Kubernertes 發行版（[安裝教學](https://microk8s.io/docs)）
 - [Helm 3](https://helm.sh/) Kubernetes 套件管理工具
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) Kubernetes CLI 工具
@@ -40,12 +60,12 @@ aliases:
 
 這份教學包含以下內容：
 
-- 使用 MicroK8s 建立一個 Kubernetes 叢集。如果你有已建好的 Kubernetes 叢集，或想使用其他的  Kubernetes 發行版，可以在建好叢集後跳至「[安裝和設定NFS](#安裝和設定-nfs)」章節。如果你是使用雲端服務提供商所提供的 Kubernetes 托管服務（例如 AKS, EKS, GKE 等），你可以考慮直接使用雲端存儲服務（例如 Azure Disk, AWS S3 等）作為 beacon 與 validator 用戶端的持久性儲存系統，而非使用 NFS。我們未來會撰寫其他文章討論這個部分。
+- 使用 MicroK8s 建立一個 Kubernetes 叢集。如果你有已建好的 Kubernetes 叢集，或想使用其他的 Kubernetes 發行版，可以在建好叢集後跳至「[安裝和設定NFS](#安裝和設定-nfs)」章節。如果你是使用雲端服務提供商所提供的 Kubernetes 托管服務（例如 AKS, EKS, GKE 等），你可以考慮直接使用雲端存儲服務（例如 Azure Disk, AWS S3 等）作為 beacon 與 validator 用戶端的持久性儲存系統，而非使用 NFS。我們未來會撰寫其他文章討論這個部分。
 - 安裝和設定 NFS。
-- 準備用以安裝 Prysm 以太坊 2.0 用戶端的 Helm Chart。
-- 使用 Helm Chart 安裝 Prysm 以太坊 2.0 用戶端。
+- 準備用以安裝以太坊 2.0 用戶端的 Helm Chart。
+- 使用 Helm Chart 安裝以太坊 2.0 用戶端。
 - 確認用戶端狀態。
-- 使用 Helm Chart 升級和回溯 Prysm 以太坊 2.0 用戶端。
+- 使用 Helm Chart 升級和回溯以太坊 2.0 用戶端。
 
 ## 非本文目標
 
@@ -58,27 +78,27 @@ aliases:
 
 ## 免責聲明
 
-這份教學的設置目前僅在以太坊測試網路上開發和測試。 
+這份教學的設置目前僅在以太坊測試網路上開發和測試。
 
 做質押挖礦（staking）的礦工要承擔相應的風險，我們強烈建議，在正式網路（mainnet）staking 前，都先在測試網路上試跑，藉此熟悉所有可能的維運操作，並透過系統在測試網路上的表現調整硬體配備，強化系統安全。這份教學僅作為使用 Kubernetes 作 staking 的設置參考，**對於因遵循本指南而造成的任何財務損失，作者概不負責。**
 
 ## 系統需求
 
-我們需要至少三台機器（虛擬機或實體機皆可）來完成這份教學的設置。一台機器會作為 NFS 伺服器來儲存 staking 資料；第二台機器作為 Kubernetes 叢集裡的「主要」（master）節點，用來運行 Kubernetes 的核心元件；第三台機器則是 Kubernetes 叢集裡的 「工作」（worker）節點用以執行 beacon 及 validator 用戶端。若要作高可用性配置，請參考 [MicroK8s 高可用性設定文件](https://microk8s.io/docs/high-availability)來新增更多的節點，並定期備份 beacon 資料，這樣在資料毀損重建時，也可以較快完成同步再次上線。我們將會在往後的文章裡討論高可用性的設置。 
+我們需要至少三台機器（虛擬機或實體機皆可）來完成這份教學的設置。一台機器會作為 NFS 伺服器來儲存 staking 資料；第二台機器作為 Kubernetes 叢集裡的「主要」（master）節點，用來運行 Kubernetes 的核心元件；第三台機器則是 Kubernetes 叢集裡的 「工作」（worker）節點用以執行 beacon 及 validator 用戶端。若要作高可用性配置，請參考 [MicroK8s 高可用性設定文件](https://microk8s.io/docs/high-availability)來新增更多的節點，並定期備份 beacon 資料，這樣在資料毀損重建時，也可以較快完成同步再次上線。我們將會在往後的文章裡討論高可用性的設置。
 
 基於在 [**Prater 測試網路**](https://prater.beaconcha.in/)上的試跑結果以及 [MicroK8s 官方文件](https://microk8s.io/docs)，以下是我們建議的最小系統需求。請注意，**最小系統需求並不保證最佳的系統表現及成本效益。**
 
-Master 主要節點： 
+Master 主要節點：
 
 - RAM: 至少 8 GB
-- CPU: 至少 1 core 
-- Disk: 至少 20 GB 
+- CPU: 至少 1 core
+- Disk: 至少 20 GB
 
 Worker 工作節點：
 
 - RAM: 至少 8 GB
-- CPU: 至少 1 core 
-- Disk: 至少 20 GB 
+- CPU: 至少 1 core
+- Disk: 至少 20 GB
 
 NFS：
 
@@ -95,12 +115,17 @@ NFS：
 
 ## 事前準備
 
-- 已為 validator 存入足夠的押金，並已產生 validator 金鑰。如果需要參考步驟，我們推薦 [Somer Esat 的教學文章](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3)。
-- 已擁有一個以太坊 1.0 測試網路 Goerli 的節點：[Somer Esat 的教學文章](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3)也包含了如何架設以太坊 1.0 的測試網路節點，你也可以選擇使用第三方的服務如 [Infura](https://infura.io/) 或 [Alchemy](https://alchemyapi.io/)。
+- 已為 validator 存入足夠的押金，並已產生 validator 金鑰。如果需要參考步驟，我們推薦 [Somer Esat 的教學文章](https://medium.com/search?q=someresat%20Guide%20to%20Staking)。
+- 已擁有一個以太坊 1.0 測試網路 Goerli 的節點：[Somer Esat 的教學文章](https://medium.com/search?q=someresat%20Guide%20to%20Staking)也包含了如何架設以太坊 1.0 的測試網路節點，你也可以選擇使用第三方的服務如 [Infura](https://infura.io/) 或 [Alchemy](https://alchemyapi.io/)。
 - 規劃好內網，設定好防火牆跟轉發通訊埠。在「[設定步驟](#設定步驟)」章節會提到我們使用的網路設定。
 - 已在三台機器安裝 Ubuntu Server 20.04.2 LTS (x64) ，並已指派靜態 IP 位址。
 
 ## 設定步驟
+
+### 選擇以太坊 2.0 用戶端
+
+之後的教學內容會根據你選擇的以太坊 2.0 用戶端而有所變動，請在繼續往下閱讀前選則一個用戶端：
+{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" active="toggle1" >}}
 
 ### 概要
 
@@ -133,7 +158,7 @@ sudo reboot
     sudo timedatectl set-timezone America/Los_Angeles
     ```
 
-2. 確認預設的 timekeeping service (NTP service) 有啟動 
+2. 確認預設的 timekeeping service (NTP service) 有啟動
 
     ```bash
     timedatectl
@@ -233,11 +258,35 @@ sudo reboot
     ```
 
 6. 在主要節點與工作節點的機器上，加入 beacon 節點所需的防火牆規則：
+{{< toggle-panel name="Prysm" active=true >}}
 
-    ```bash
-    sudo ufw allow 12000/udp
-    sudo ufw allow 13000/tcp
-    ```
+```bash
+sudo ufw allow 12000/udp
+sudo ufw allow 13000/tcp
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+```bash
+sudo ufw allow 9000
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+```bash
+sudo ufw allow 9000
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+```bash
+sudo ufw allow 9000
+```
+
+{{< /toggle-panel >}}
 
 7. 最後，在每一台機器上啟動防火牆服務
 
@@ -258,7 +307,7 @@ sudo reboot
     sudo snap install microk8s --classic --channel=1.20/stable
     ```
 
-2. 授予非管理員使用者（non-root user）管理 MicroK8s 的權限。將該使用者加入 MicroK8s 的群組中，並改變`~/.kube` 目錄的所有權：
+2. 授予非管理員使用者（non-root user）管理 MicroK8s 的權限。將該使用者加入 MicroK8s 的群組中，並改變`~/.kube`目錄的所有權：
 
     ```bash
     sudo usermod -a -G microk8s $USER
@@ -339,6 +388,8 @@ sudo reboot
     sudo systemctl start nfs-kernel-server.service
     ```
 
+{{< toggle-panel name="Prysm" active=true >}}
+
 2. 為 beacon、validator 用戶端及錢包建資料目錄
 
     ```bash
@@ -348,11 +399,59 @@ sudo reboot
     sudo mkdir -p /data/prysm/validator-client-2 /data/prysm/wallet-2
     ```
 
-    **請注意每一個錢包只能讓一個 validator 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個錢包，並讓一個 validator 用戶端來為多個 validators 提交區塊驗證結果。
-    
-    **為避免 slashing，請不要讓多個 validator 用戶端使用同一個錢包，或將同一把 validator 金鑰匯入多個有 validator 使用的錢包。**
+    **請注意每一個錢包只能讓一個 validator 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個錢包，並讓一個 validator 用戶端來為多個 validators 金鑰提交區塊驗證結果。
 
-3. 設定並匯出 NFS 儲存空間
+    **為避免 slashing，請不要讓多個 validator 用戶端使用同一個錢包，或將同一把 validator 金鑰匯入多個有 validator 用戶端使用的錢包。**
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+2. 為 beacon 及 validator 用戶端建資料目錄
+
+    ```bash
+    sudo mkdir -p /data/lighthouse/beacon
+
+    sudo mkdir -p /data/lighthouse/validator-client-1
+    sudo mkdir -p /data/lighthouse/validator-client-2
+    ```
+
+    **請注意每一個金鑰只能讓一個 validator 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個 validator 用戶端，並讓一個 validator 用戶端來為多個 validators 金鑰提交區塊驗證結果。
+
+    **為避免 slashing，請不要匯入同一個金鑰到多個 validator 用戶端。**
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+2. 為 beacon、validator 用戶端、validator 金鑰及金鑰密碼建資料目錄
+
+    ```bash
+    sudo mkdir -p /data/teku/beacon
+
+    sudo mkdir -p /data/teku/validator-client-1 /data/teku/validator-keys-1 /data/teku/validator-key-passwords-1
+    sudo mkdir -p /data/teku/validator-client-2 /data/teku/validator-keys-2 /data/teku/validator-key-passwords-2
+    ```
+
+    **請注意每一個金鑰只能讓一個 validator 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個 validator 用戶端，並讓一個 validator 用戶端來為多個 validators 金鑰提交區塊驗證結果。
+
+    **為避免 slashing，請不要匯入同一個金鑰到多個 validator 用戶端。**
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+2. 為 beacon、validator及秘密建資料目錄
+
+    ```bash
+    sudo mkdir -p /data/nimbus/beacon-1 /data/nimbus/validators-1 /data/nimbus/secrets-1
+    sudo mkdir -p /data/nimbus/beacon-2 /data/nimbus/validators-2 /data/nimbus/secrets-2
+    ```
+
+    **P請注意每一個金鑰只能讓一個 Nimbus 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個用戶端，並讓一個用戶端來為多個 validators 金鑰提交區塊驗證結果。
+
+    **為避免 slashing，請不要匯入同一個金鑰到多個 Nimbus 用戶端。**
+
+{{< /toggle-panel >}}
+
+1. 設定並匯出 NFS 儲存空間
 
     ```bash
     sudo nano /etc/exports
@@ -366,7 +465,7 @@ sudo reboot
 
     設定選項敘述：
 
-    - **\***: hostname 格式 
+    - **\***: hostname 格式
     - **rw**: 讀寫權限
     - **sync**: 在回覆更動要求前，所有的改變都保證會被寫入儲存空間
     - **no_subtree_check**: 如果設定中包含 no_subtree_check 這個值，之後將不會檢查 subtree。雖然這個設定可能帶來一些安全疑慮，但在某些狀況下，穩定性會因此提升。因為 subtree_checking 比起 no_subtree_check 會造成更多問題，在 nfs-utils 版本 1.1.0 及往後版本，預設值都是 no_subtree_check。
@@ -379,8 +478,7 @@ sudo reboot
     sudo exportfs -a
     ```
 
-
-4. 在主要節點及工作節點上安裝`nfs-common`以支援 NFS：
+2. 在主要節點及工作節點上安裝`nfs-common`以支援 NFS：
 
     ```bash
     sudo apt install nfs-common
@@ -388,24 +486,69 @@ sudo reboot
 
 ### 匯入 Validator 金鑰
 
-你可以直接參考 [Prysm 官方文件](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm)，或參考以下步驟來完成錢包設定：
+這一個章節我們要來匯入使用 [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli) 產生的 validator 金鑰。在設定前，請先確認 validator 金鑰已經傳到 NFS 伺服器上。
+{{< toggle-panel name="Prysm" active=true >}}
 
-在設定錢包前，請先確認 validator 金鑰已經傳到 NFS 伺服器上。這一個章節我們要來用上一章裡建好的錢包目錄來建立錢包並匯入 validator 金鑰。
+你可以直接參考 [Prysm 官方文件](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm)，或參考以下步驟來完成設定：
 
-我們使用 Prysm 提供的腳本來完成設定：
 1. 請參考 [Prysm 官方文件](https://docs.prylabs.network/docs/install/install-with-script/#downloading-the-prysm-startup-script)下載設定腳本（Prysm startup script）
 
 2. 執行腳本時要提供金鑰所在的目錄路徑到`--keys-dir=<path/to/validator-keys>`參數。我們的範例裡使用`$HOME/eth2.0-deposit-cli/validator_keys`當作金鑰目錄
 
     ```bash
-    sudo ./prysm.sh validator accounts import --keys-dir=$HOME/eth2.0-deposit-cli/validator_keys
+    sudo ./prysm.sh validator accounts import --keys-dir=$HOME/eth2.0-deposit-cli/validator_keys --prater
     ```
 
 3. 接著輸入錢包目錄路徑，例如`/data/prysm/wallet-1`
 
 4. 輸入錢包密碼（**記得備份在一個安全的地方！**)
 
-5. 接著輸入 validator 金鑰的密碼（使用 [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli) 產生 validator 金鑰時所建立的那組密碼）。如果輸入正確，即可成功匯入 validator 帳號至錢包裡。
+5. 接著輸入 validator 金鑰的密碼（使用`eth2.0-deposit-cli`產生 validator 金鑰時所建立的那組密碼）。如果輸入正確，即可成功匯入 validator 帳號至錢包裡。
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+你可以直接參考 [Lighthouse 官方文件](https://lighthouse-book.sigmaprime.io/validator-import-launchpad.html)，或參考以下步驟來完成設定：
+
+1. 請參考 [Lighthouse 官方文件](https://lighthouse-book.sigmaprime.io/installation-binaries.html)下載編譯好的執行檔
+
+2. 執行時要提供金鑰所在的目錄路徑到`--directory=<path/to/validator-keys>`參數。我們的範例裡使用`$HOME/eth2.0-deposit-cli/validator_keys`當作金鑰目錄以及`/data/lighthouse/validator-client-1`當作 validator 用戶端的資料目錄
+
+    ```bash
+    sudo ./lighthouse --network prater account validator import --directory $HOME/eth2.0-deposit-cli/validator_keys --datadir /data/lighthouse/validator-client-1 --reuse-password
+    ```
+
+3. 接著輸入 validator 金鑰的密碼（使用`eth2.0-deposit-cli`產生 validator 金鑰時所建立的那組密碼）。如果輸入正確，即可成功匯入 validator 金鑰。
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+你可以直接參考 [Teku 官方文件](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#generate-the-validators-and-send-the-deposits)，或參考以下步驟來完成設定：
+
+1. 複製 validator 金鑰到我們預計存放金鑰的目錄裡。假設我們使用`eth2.0-deposit-cli`產生的金鑰在`$HOME/eth2.0-deposit-cli/validator_keys`目錄，而我們預計將金鑰存放在`/data/teku/validator-keys-1`目錄
+
+    ```bash
+    sudo cp  $HOME/eth2.0-deposit-cli/validator_keys/* /data/teku/validator-keys-1/
+    ```
+
+2. 替每一把金鑰產生一個相對應的 txt 密碼檔（使用`eth2.0-deposit-cli`產生 validator 金鑰時所建立的那組密碼），並將密碼檔們移到們預計存放密碼的目錄裡（假設是`/data/teku/validator-key-passwords-1`）。例如，如果有一把金鑰的名稱是`keystore-m_123.json`, 我們需要產一個名為`keystore-m_123.txt`的檔案並把密碼存在檔案裡
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+你可以直接參考 [Nimbus 官方文件](https://nimbus.guide/keys.html)，或參考以下步驟來完成設定：
+
+1. 請參考 [Nimbus 官方文件](https://nimbus.guide/binaries.html)下載編譯好的執行檔
+
+2. 執行時要提供金鑰所在的目錄路徑。我們的範例裡使用`$HOME/eth2.0-deposit-cli/validator_keys`當作金鑰目錄以及`/data/nimbus-1`當作 Nimbus 用戶端的資料目錄
+
+    ```bash
+    sudo nimbus_beacon_node deposits import --data-dir=/data/nimbus-1 $HOME/eth2.0-deposit-cli/validator_keys
+    ```
+
+3. 接著輸入 validator 金鑰的密碼（使用`eth2.0-deposit-cli`產生 validator 金鑰時所建立的那組密碼）。如果輸入正確，即可成功匯入 validator 金鑰。
+
+{{< /toggle-panel >}}
 
 ### 改變資料目錄擁有者
 
@@ -427,24 +570,77 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     git clone https://github.com/lumostone/eth2xk8s.git
     ```
 
+{{< toggle-panel name="Prysm" active=true >}}
+
 2. 更改 [prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml) 的值
 
     建議閱讀`values.yaml`的每個變數及說明，確認是否更改預設值。以下列出安裝 Helm Chart 前必須更改的變數：
     - **nfs.serverIp**: NFS 伺服器 IP 地址
-    - **nfs.user**: 容器（container）裡的每個程序（process）會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
-    - **nfs.group**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
-    - **image.version**: Prysm 用戶端版本
+    - **securityContext.runAsUse**: 容器裡的每個程序會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
+    - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
+    - **image.versionTag**: Prysm 用戶端版本
     - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
     - **beacon.web3Provider** 及 **beacon.fallbackWeb3Providers**: 以太坊 1.0 節點網址
+    - **validatorClients.validatorClient1**
+      - **.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
+      - **.walletVolumePath**: NFS 上的錢包資料目錄路徑
+      - **.walletPassword**: 錢包密碼
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+2. 更改 [lighthouse/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/lighthouse/helm/values.yaml) 的值
+
+    建議閱讀`values.yaml`的每個變數及說明，確認是否更改預設值。以下列出安裝 Helm Chart 前必須更改的變數：
+    - **nfs.serverIp**: NFS 伺服器 IP 地址
+    - **securityContext.runAsUse**: 容器裡的每個程序會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
+    - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
+    - **image.versionTag**: Lighthouse 用戶端版本
+    - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
+    - **beacon.eth1Endpoints**: 以太坊 1.0 節點網址
     - **validatorClients.validatorClient1.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
-    - **validatorClients.validatorClient1.walletVolumePath**: NFS 上的錢包資料目錄路徑
-    - **validatorClients.validatorClient1.walletPassword**: 錢包密碼
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+2. 更改 [teku/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/teku/helm/values.yaml) 的值
+
+    建議閱讀`values.yaml`的每個變數及說明，確認是否更改預設值。以下列出安裝 Helm Chart 前必須更改的變數：
+    - **nfs.serverIp**: NFS 伺服器 IP 地址
+    - **securityContext.runAsUse**: 容器裡的每個程序會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
+    - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
+    - **image.versionTag**: Teku 用戶端版本
+    - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
+    - **beacon.eth1Endpoint**: 以太坊 1.0 節點網址
+    - **validatorClients.validatorClient1**
+      - **.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
+      - **.validatorKeysVolumePath**: NFS 上的 validator 金鑰資料目錄路徑
+      - **.validatorKeyPasswordsVolumePath**: NFS 上的 validator 金鑰密碼資料目錄路徑
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+2. 更改 [nimbus/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/nimbus/helm/values.yaml) 的值
+
+    建議閱讀`values.yaml`的每個變數及說明，確認是否更改預設值。以下列出安裝 Helm Chart 前必須更改的變數：
+    - **nfs.serverIp**: NFS 伺服器 IP 地址
+    - **securityContext.runAsUse**: 容器裡的每個程序會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
+    - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
+    - **image.versionTag**: Nimbus 用戶端版本
+    - **nimbus.clients.client1**
+      - **.web3Provider** and **.fallbackWeb3Providers**: 以太坊 1.0 節點網址
+      - **.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
+      - **.validatorsVolumePath**: NFS 上的 validator 金鑰存放區資料目錄路徑
+      - **.secretsVolumePath**: NFS 上的 validator 金鑰存放區秘密資料目錄路徑
+
+{{< /toggle-panel >}}
 
 ### 使用 Helm Chart 安裝 Prysm
 
-Kubernetes 使用 [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) 來作命名及資源區隔及存取限制。我們使用`prysm`當作 Prysm 用戶端的 namespace。
+Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart 的安裝紀錄。在這篇教學裡，我們用`eth2xk8s`當作我們的 release 名字，你也可以改成其他你想要的名字。我們會在安裝 Helm Chart 時指定要安裝在什麼 [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) 內（Kubernetes 使用 namespace 來區隔資源及限制存取）。
 
-Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart 的安裝紀錄。在這篇教學裡，我們用`eth2xk8s`當作我們的 release 名字，你也可以改成其他你想要的名字。
+{{< toggle-panel name="Prysm" active=true >}}
+我們使用`prysm`當作 Prysm 用戶端的 namespace。
 
 在主要節點上：
 
@@ -466,7 +662,83 @@ Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart �
     microk8s helm3 get manifest eth2xk8s -nprysm
     ```
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+我們使用`lighthouse`當作 Lighthouse 用戶端的 namespace。
+
+在主要節點上：
+
+1. 創造一個 namespace
+
+    ```bash
+    microk8s kubectl create namespace lighthouse
+    ```
+
+2. 安裝 Lighthouse 用戶端
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./lighthouse/helm -nlighthouse
+    ```
+
+3. 檢查部署設定
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nlighthouse
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+我們使用`teku`當作 Teku 用戶端的 namespace。
+
+在主要節點上：
+
+1. 創造一個 namespace
+
+    ```bash
+    microk8s kubectl create namespace teku
+    ```
+
+2. 安裝 Teku 用戶端
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./teku/helm -nteku
+    ```
+
+3. 檢查部署設定
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nteku
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+我們使用`nimbus`當作 Nimbus 用戶端的 namespace。
+
+在主要節點上：
+
+1. 創造一個 namespace
+
+    ```bash
+    microk8s kubectl create namespace nimbus
+    ```
+
+2. 安裝 Nimbus 用戶端
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./nimbus/helm -nnimbus
+    ```
+
+3. 檢查部署設定
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nnimbus
+    ```
+
+{{< /toggle-panel >}}
+
 ### 檢查用戶端狀態
+
+{{< toggle-panel name="Prysm" active=true >}}
 
 1. 檢查部署狀態
 
@@ -488,19 +760,104 @@ Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart �
     microk8s kubectl logs -f -nprysm -l app=validator-client-1
     ```
 
-    如果想檢查其他的 validator用戶端，可以將`-l app=<validator client name>`更改成在`values.yaml`設定的其他 validator 用戶端的名字，以 validator-client-2 為例
+    如果想檢查其他的 validator 用戶端，可以將`-l app=<validator client name>`更改成在`values.yaml`設定的其他 validator 用戶端的名字，以 validator-client-2 為例
 
     ```bash
     microk8s kubectl logs -f -nprysm -l app=validator-client-2
     ```
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+1. 檢查部署狀態
+
+    ```bash
+    microk8s kubectl get pod -nlighthouse -w
+    ```
+
+    這個指令會持續監控狀態變化，我們只需等到 beacon 及 validator 用戶端都變成 Running 狀態即可。
+
+2. 檢查 beacon 的執行記錄
+
+    ```bash
+    microk8s kubectl logs -f -nlighthouse -l app=beacon
+    ```
+
+3. 檢查 validator 用戶端的執行記錄
+
+    ```bash
+    microk8s kubectl logs -f -nlighthouse -l app=validator-client-1
+    ```
+
+    如果想檢查其他的 validator 用戶端，可以將`-l app=<validator client name>`更改成在`values.yaml`設定的其他 validator 用戶端的名字，以 validator-client-2 為例
+
+    ```bash
+    microk8s kubectl logs -f -nlighthouse -l app=validator-client-2
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+1. 檢查部署狀態
+
+    ```bash
+    microk8s kubectl get pod -nteku -w
+    ```
+
+    這個指令會持續監控狀態變化，我們只需等到 beacon 及 validator 用戶端都變成 Running 狀態即可。
+
+2. 檢查 beacon 的執行記錄
+
+    ```bash
+    microk8s kubectl logs -f -nteku -l app=beacon
+    ```
+
+3. 檢查 validator 用戶端的執行記錄
+
+    ```bash
+    microk8s kubectl logs -f -nteku -l app=validator-client-1
+    ```
+
+    如果想檢查其他的 validator 用戶端，可以將`-l app=<validator client name>`更改成在`values.yaml`設定的其他 validator 用戶端的名字，以 validator-client-2 為例
+
+    ```bash
+    microk8s kubectl logs -f -nteku -l app=validator-client-2
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+1. 檢查部署狀態
+
+    ```bash
+    microk8s kubectl get pod -nnimbus -w
+    ```
+
+    這個指令會持續監控狀態變化，我們只需等到用戶端都變成 Running 狀態即可。
+
+2. 檢查 Nimbus 用戶端的執行記錄
+
+    ```bash
+    microk8s kubectl logs -f -nnimbus -l app=nimbus-1
+    ```
+
+    如果想檢查其他的 Nimbus 用戶端，可以將`-l app=<nimbus client name>`更改成在`values.yaml`設定的其他 Nimbus 用戶端的名字，以 nimbus-2 為例
+
+    ```bash
+    microk8s kubectl logs -f -nnimbus -l app=nimbus-2
+    ```
+
+{{< /toggle-panel >}}
+
 ### 使用 Helm Chart 更新 Prysm 版本
 
 以太坊 2.0 用戶端的新版本推出速度很快，我們應該盡快更新用戶端版本來獲得最新的 bug fixes 和功能。為了簡化版本跟軟體部署的管理，我們推薦用 Helm 來更新版本：
 
+{{< toggle-panel name="Prysm" active=true >}}
+
 1. 到 [Prysm Github 版本釋出頁面](https://github.com/prysmaticlabs/prysm/releases)查看最新版本
 
-2. 將`values.yaml`中的 **image.version** 改成最新版本（例如 `v1.3.4`）並儲存`values.yaml`
+2. 將`values.yaml`中的 `image.versionTag` 改成最新版本（例如`v1.3.4`）並儲存`values.yaml`
 
 3. 執行以下 Helm 指令更新用戶端
 
@@ -514,11 +871,72 @@ Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart �
     microk8s helm3 get manifest eth2xk8s -nprysm
     ```
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+1. 到 [Lighthouse Github 版本釋出頁面](https://github.com/sigp/lighthouse/releases)查看最新版本
+
+2. 將`values.yaml`中的 `image.versionTag` 改成最新版本（例如`v1.3.0`）並儲存`values.yaml`
+
+3. 執行以下 Helm 指令更新用戶端
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./lighthouse/helm -nlighthouse
+    ```
+
+4. 檢查部署設定，確認用戶端已更新成新版本
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nlighthouse
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+1. 到 [Teku Github 版本釋出頁面](https://github.com/ConsenSys/teku/releases)查看最新版本
+
+2. 將`values.yaml`中的 `image.versionTag` 改成最新版本（例如`21.4.1`）並儲存`values.yaml`
+
+3. 執行以下 Helm 指令更新用戶端
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./teku/helm -nteku
+    ```
+
+4. 檢查部署設定，確認用戶端已更新成新版本
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nteku
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+1. 到 [Nimbus Github 版本釋出頁面](https://github.com/status-im/nimbus-eth2/releases)查看最新版本
+
+2. 將`values.yaml`中的 `image.versionTag` 改成最新版本（例如`amd64-v1.2.`）並儲存`values.yaml`
+
+3. 執行以下 Helm 指令更新用戶端
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./nimbus/helm -nnimbus
+    ```
+
+4. 檢查部署設定，確認用戶端已更新成新版本
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nnimbus
+    ```
+
+{{< /toggle-panel >}}
+
 5. 依照「[檢查用戶端狀態](#檢查用戶端狀態)」章節檢查用戶端是否正常執行
 
 ### 使用 Helm 回溯版本
 
-如果版本回溯不牽涉資料庫 schema 變動的話，使用 Helm 回溯版本就跟更新一樣直覺。以下是範例步驟及指令：
+如果版本回溯前需要先還原資料庫 schema，可以參照「[使用 Helm 回溯版本（如果資料庫 Schema 有更動)](#使用-helm-回溯版本如果資料庫-schema-有更動)」章節。如果版本回溯不牽涉資料庫 schema 變動的話，使用 Helm 回溯版本就跟更新一樣直覺。以下是範例步驟及指令：
+
+{{< toggle-panel name="Prysm" active=true >}}
 
 1. 使用`helm history`指令找出並記下想要回溯到的版本號碼
 
@@ -534,13 +952,70 @@ Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart �
 
 3. 接著依照「[檢查用戶端狀態](#檢查用戶端狀態)」章節檢查部署設定以及用戶端是否正常執行。
 
-如果版本回溯前需要先還原資料庫 schema，可以參照「[使用 Helm 回溯版本（如果資料庫 Schema 有更動)](#使用-helm-回溯版本如果資料庫-schema-有更動)」章節。
-
 某些情況下有可能沒辦法回溯到之前的版本（[例子](https://docs.prylabs.network/docs/prysm-usage/staying-up-to-date/#downgrading-between-major-version-bumps)），在回溯前記得先確認用戶端相關文件。
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+1. 使用`helm history`指令找出並記下想要回溯到的版本號碼
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nlighthouse
+    ```
+
+2. 回溯到指定版本（以下指令假設我們要回溯到版本 4）
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nlighthouse
+    ```
+
+3. 接著依照「[檢查用戶端狀態](#檢查用戶端狀態)」章節檢查部署設定以及用戶端是否正常執行。
+
+某些情況下有可能沒辦法回溯到之前的版本，在回溯前記得先確認用戶端相關文件。
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+1. 使用`helm history`指令找出並記下想要回溯到的版本號碼
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nteku
+    ```
+
+2. 回溯到指定版本（以下指令假設我們要回溯到版本 4）
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nteku
+    ```
+
+3. 接著依照「[檢查用戶端狀態](#檢查用戶端狀態)」章節檢查部署設定以及用戶端是否正常執行。
+
+某些情況下有可能沒辦法回溯到之前的版本，在回溯前記得先確認用戶端相關文件。
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+1. 使用`helm history`指令找出並記下想要回溯到的版本號碼
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nnimbus
+    ```
+
+2. 回溯到指定版本（以下指令假設我們要回溯到版本 4）
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nnimbus
+    ```
+
+3. 接著依照「[檢查用戶端狀態](#檢查用戶端狀態)」章節檢查部署設定以及用戶端是否正常執行。
+
+某些情況下有可能沒辦法回溯到之前的版本，在回溯前記得先確認用戶端相關文件。
+
+{{< /toggle-panel >}}
 
 ## 結論
 
-感謝你的閱讀！我們希望這篇文章能夠幫助想要使用 Kubernetes 來做以太坊 2.0 staking 的你。我們會繼續製作相關教學，之後我們也會開發給其他以太坊 2.0 用戶端的 Helm Chart。敬請期待！
+感謝你的閱讀！我們希望這篇文章能夠幫助想要使用 Kubernetes 來做以太坊 2.0 staking 的你。我們會繼續製作相關教學。敬請期待！
 
 ## 有任何建議或是疑問嗎？
 
@@ -560,20 +1035,74 @@ Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart �
 
 2. 接著可以執行`kubectl top`指令來得到用量資訊，下面兩個例子分別會得到 beacon 及 validator 用戶端的用量。
 
-    ```bash
-    microk8s kubectl top pod -l app=beacon
-    microk8s kubectl top pod -l app=validator-client-1
-    ```
+{{< toggle-panel name="Prysm" active=true >}}
+
+```bash
+microk8s kubectl top pod -l app=beacon
+microk8s kubectl top pod -l app=validator-client-1
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+```bash
+microk8s kubectl top pod -l app=beacon
+microk8s kubectl top pod -l app=validator-client-1
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+```bash
+microk8s kubectl top pod -l app=beacon
+microk8s kubectl top pod -l app=validator-client-1
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+```bash
+microk8s kubectl top pod -l app=nimbus-1
+```
+
+{{< /toggle-panel >}}
 
 ### 解除安裝 Helm Chart
 
-如果想要停止執行以及移除 Prysm，可以執行以下指令來移除整個 Helm Chart：
+如果想要停止執行以及移除以太坊 2.0 用戶端，可以執行以下指令來移除整個 Helm Chart：
+
+{{< toggle-panel name="Prysm" active=true >}}
 
 ```bash
 microk8s helm3 uninstall eth2xk8s -nprysm
 ```
 
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nlighthouse
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nteku
+```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nnimbus
+```
+
+{{< /toggle-panel >}}
+
 ### 使用 Helm 回溯版本（如果資料庫 Schema 有更動）
+
+{{< toggle-panel name="Prysm" active=true >}}
 
 以 [Prysm v1.3.0 版本](https://github.com/prysmaticlabs/prysm/releases/tag/v1.3.0)為例，如果想要回溯至 v1.2.x，我們需要在回溯前先跑一個腳本來還原 v1.3.0 帶來的資料庫 schema 變動。所以如果我們照著「[使用 Helm 回溯版本](#使用-helm-回溯版本)」的步驟執行指令，在用 Helm 改變 Prsym 版本成 v1.2.2 之後，所有的 pods 會馬上重啟，但 Prysm 可能會因為資料庫 schema 只適用於 v1.3.0 版本而無法正常啟動。
 
@@ -619,3 +1148,140 @@ microk8s helm3 uninstall eth2xk8s -nprysm
     ```bash
     microk8s kubectl get pod -nprysm -w
     ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Lighthouse" >}}
+
+如果在新版本有 schema 變動的情況下，想要回溯至先前的版本，我們有可能可以使用用戶端團隊提供的工具來還原 schema 變動。所以如果我們照著「[使用 Helm 回溯版本](#使用-helm-回溯版本)」的步驟執行指令，在用 Helm 改變版本之後，所有的 pods 會馬上重啟，但用戶端可能會因為資料庫 schema 只適用於新版本而無法正常啟動。
+
+要解決這個問題，我們可以利用 Kubernetes 暫時把 pod 的數量降成 0。在此期間，不會有任何用戶端能夠執行，我們也就能趁機復原新版本帶來的 schema 變動，然後再恢復 pod 的數量，最後再回溯版本。以下是範例步驟及指令：
+
+1. 在還原版本前，用以下指令先把 pod 的數量降成 0
+
+    只調整 beacon：
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nlighthouse --replicas=0
+    ```
+
+    如果 schema 變動只影響 validator，我們可以只調整 validator 用戶端：
+
+    ```bash
+    microk8s kubectl scale deployments/validator-client-1 -nlighthouse --replicas=0
+    ```
+
+2. 確認所有 pod 都已停止
+
+    ```bash
+    microk8s kubectl get pod -nlighthouse -w
+    ```
+
+3. 復原 schema 變動
+
+4. 回溯到版本 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nlighthouse
+    ```
+
+5. 恢復 beacon 及 validator 用戶端 pod 的數量
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nlighthouse --replicas=1
+    microk8s kubectl scale deployments/validator-client-1 -nlighthouse --replicas=1
+    ```
+
+6. 確認所有 pod 都恢復執行
+
+    ```bash
+    microk8s kubectl get pod -nlighthouse -w
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Teku" >}}
+
+如果在新版本有 schema 變動的情況下，想要回溯至先前的版本，我們有可能可以使用用戶端團隊提供的工具來還原 schema 變動。所以如果我們照著「[使用 Helm 回溯版本](#使用-helm-回溯版本)」的步驟執行指令，在用 Helm 改變版本之後，所有的 pods 會馬上重啟，但用戶端可能會因為資料庫 schema 只適用於新版本而無法正常啟動。
+
+要解決這個問題，我們可以利用 Kubernetes 暫時把 pod 的數量降成 0。在此期間，不會有任何用戶端能夠執行，我們也就能趁機復原新版本帶來的 schema 變動，然後再恢復 pod 的數量，最後再回溯版本。以下是範例步驟及指令：
+
+1. 在還原版本前，用以下指令先把 pod 的數量降成 0
+
+    只調整 beacon：
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nteku --replicas=0
+    ```
+
+    如果 schema 變動只影響 validator，我們可以只調整 validator 用戶端：
+
+    ```bash
+    microk8s kubectl scale deployments/validator-client-1 -nteku --replicas=0
+    ```
+
+2. 確認所有 pod 都已停止
+
+    ```bash
+    microk8s kubectl get pod -nteku -w
+    ```
+
+3. 復原 schema 變動
+
+4. 回溯到版本 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nteku
+    ```
+
+5. 恢復 beacon 及 validator 用戶端 pod 的數量
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nteku --replicas=1
+    microk8s kubectl scale deployments/validator-client-1 -nteku --replicas=1
+    ```
+
+6. 確認所有 pod 都恢復執行
+
+    ```bash
+    microk8s kubectl get pod -nteku -w
+    ```
+
+{{< /toggle-panel >}}
+{{< toggle-panel name="Nimbus" >}}
+
+如果在新版本有 schema 變動的情況下，想要回溯至先前的版本，我們有可能可以使用用戶端團隊提供的工具來還原 schema 變動。所以如果我們照著「[使用 Helm 回溯版本](#使用-helm-回溯版本)」的步驟執行指令，在用 Helm 改變版本之後，所有的 pods 會馬上重啟，但用戶端可能會因為資料庫 schema 只適用於新版本而無法正常啟動。
+
+要解決這個問題，我們可以利用 Kubernetes 暫時把 pod 的數量降成 0。在此期間，不會有任何用戶端能夠執行，我們也就能趁機復原新版本帶來的 schema 變動，然後再恢復 pod 的數量，最後再回溯版本。以下是範例步驟及指令：
+
+1. 在還原版本前，用以下指令先把 pod 的數量降成 0
+
+    ```bash
+    microk8s kubectl scale deployments/nimbus-1 -nnimbus --replicas=0
+    ```
+
+2. 確認所有 pod 都已停止
+
+    ```bash
+    microk8s kubectl get pod -nnimbus -w
+    ```
+
+3. 復原 schema 變動
+
+4. 回溯到版本 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nnimbus
+    ```
+
+5. 恢復用戶端 pod 的數量
+
+    ```bash
+    microk8s kubectl scale deployments/nimbus-1 -nnimbus --replicas=1
+    ```
+
+6. 確認所有 pod 都恢復執行
+
+    ```bash
+    microk8s kubectl get pod -nnimbus -w
+    ```
+
+{{< /toggle-panel >}}

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -1,0 +1,617 @@
+---
+title: "當以太幣質押挖礦機遇見 Kubernetes－架設教學"
+date: 2021-04-19T23:53:09Z
+draft: false
+tags: ["以太坊", "kubernetes", "教學"]
+---
+
+## 為什麼使用 Kubernetes 作 staking？
+作為 staker，我們常擔憂 validator 是否會突然停機，或是被區塊鏈上其他節點認作是壞成員而遭到驅逐（slashing）。如何最小化停機時間和降低被驅逐的風險，成為了一個 staker 時常考慮的問題。
+
+停機的原因百百種，可能是系統需要執行更新，軟體有問題，網路斷線，硬碟罷工等等。我們都希望可以時時監控，一旦有問題發生就立刻處理，但問題可大可小，不是每一次都能很快修復，除非是全職 staking，不然一般也沒辦法二十四小時監控處理。面對這種有高可用性的需求情境時，我們很自然地會想到 redundancy，如果怕一台機器停工，那我就再多準備幾台機器，一旦有問題就可以把系統轉移到健康的機器。
+
+然而，我們常在論壇上看到 staker 們彼此警告「redundancy 可能會導致 slashing」，因為在轉移系統的過程，可能會因為手動操作疏失，不小心讓多個 validator 用戶端同時使用同一個 validator 金鑰，或是 slashing protection database 移轉時資料毀損，新的 validator 太快上線，又重新上傳了已經驗證過的區塊等等，這些都會讓 validator 面臨 slashing 的懲罰。當我們有多個 validator ，又同時想要追求 redundancy、高可用性，這些維運複雜度就會跟著上升，追求 redundancy 反而產生更多 slashing 的風險。
+
+**我們有可能降低 slashing 風險跟維運複雜度，同時又能擁抱 redundancy 帶給我們的好處嗎？** 有的！我們認為 [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) 可以幫我們做到這件事，運用 Kubernetes 管理 validator 的生命週期，自動化容錯移轉（failover），在軟體更新時，只需要更改版本號，Kubernetes 就可以幫我們安全升級，今天硬體要更新，要手動移轉 validator 時，僅用一個指令便能完成（例如：`kubectl drain node`）。 
+
+我們希望這篇教學文章可以作為以太坊 2.0 staker community 的墊腳石，讓 stakers 可以利用 Kubernetes 建立一個有擴充性又有 redundancy 的基礎架構，一起輕鬆 staking！
+
+## 感謝
+謝謝以太坊基金會以 [Eth2 Staking Community Grants](https://blog.ethereum.org/2021/02/09/esp-staking-community-grantee-announcement/) 支持這個專案，能夠對 staker community 貢獻是我們的榮幸！
+
+
+## 使用工具
+
+這份教學將示範如何在一個 Kubernetes 叢集上維運一個以太坊 2.0 beacon 用戶端和多個 validator 用戶端， 以下是我們使用的工具：
+
+- [Prysm](https://github.com/prysmaticlabs/prysm) 以太坊 2.0 用戶端
+- [MicroK8s](https://microk8s.io/) 輕量的 Kubernertes 發行版（[安裝教學](https://microk8s.io/docs)）
+- [Helm 3](https://helm.sh/) Kubernetes 套件管理工具
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) Kubernetes CLI 工具
+- Ubuntu Server 20.04.2 LTS (x64) （[下載連結](https://ubuntu.com/download/server)）
+- [Network File System (NFS)](https://en.wikipedia.org/wiki/Network_File_System) 作為 beacon 與 validator 用戶端的持久性儲存系統（[Ubuntu 文件與教學](https://ubuntu.com/server/docs/service-nfs)）
+- [eth2xk8s](https://github.com/lumostone/eth2xk8s) Helm Chart
+
+## 本文目標
+
+這份教學包含以下內容：
+
+- 使用 MicroK8s 建立一個 Kubernetes 叢集。如果你有已建好的 Kubernetes 叢集，或想使用其他的  Kubernetes 發行版，可以在建好叢集後跳至「[安裝和設定NFS](#安裝和設定-nfs)」章節。如果你是使用雲端服務提供商所提供的 Kubernetes 托管服務（例如 AKS, EKS, GKE 等），你可以考慮直接使用雲端存儲服務（例如 Azure Disk, AWS S3 等）作為 beacon 與 validator 用戶端的持久性儲存系統，而非使用 NFS。我們未來會撰寫其他文章討論這個部分。
+- 安裝和設定 NFS。
+- 準備用以安裝 Prysm 以太坊 2.0 用戶端的 Helm Chart。
+- 使用 Helm Chart 安裝 Prysm 以太坊 2.0 用戶端。
+- 確認用戶端狀態。
+- 使用 Helm Chart 升級和回溯 Prysm 以太坊 2.0 用戶端。
+
+## 非本文目標
+
+這份教學**不包含**：
+
+- 如何調校系統或軟體表現及資源用量。
+- 如何存入 validator 押金並產生 validator 金鑰。
+- 如何設定高可用性的 Kubernetes 叢集。
+- 如何強化 Kubernetes 叢集安全性。
+
+## 免責聲明
+
+這份教學的設置目前僅在以太坊測試網路上開發和測試。 
+
+做質押挖礦（staking）的礦工要承擔相應的風險，我們強烈建議，在正式網路（mainnet）staking 前，都先在測試網路上試跑，藉此熟悉所有可能的維運操作，並透過系統在測試網路上的表現調整硬體配備，強化系統安全。這份教學僅作為使用 Kubernetes 作 staking 的設置參考，**對於因遵循本指南而造成的任何財務損失，作者概不負責。**
+
+## 系統需求
+
+我們需要至少三台機器（虛擬機或實體機皆可）來完成這份教學的設置。一台機器會作為 NFS 伺服器來儲存 staking 資料；第二台機器作為 Kubernetes 叢集裡的「主要」（master）節點，用來運行 Kubernetes 的核心元件；第三台機器則是 Kubernetes 叢集裡的 「工作」（worker）節點用以執行 beacon 及 validator 用戶端。若要作高可用性配置，請參考 [MicroK8s 高可用性設定文件](https://microk8s.io/docs/high-availability)來新增更多的節點，並定期備份 beacon 資料，這樣在資料毀損重建時，也可以較快完成同步再次上線。我們將會在往後的文章裡討論高可用性的設置。 
+
+基於在 [**Prater 測試網路**](https://prater.beaconcha.in/)上的試跑結果以及 [MicroK8s 官方文件](https://microk8s.io/docs)，以下是我們建議的最小系統需求。請注意，**最小系統需求並不保證最佳的系統表現及成本效益。**
+
+Master 主要節點： 
+
+- RAM: 至少 8 GB
+- CPU: 至少 1 core 
+- Disk: 至少 20 GB 
+
+Worker 工作節點：
+
+- RAM: 至少 8 GB
+- CPU: 至少 1 core 
+- Disk: 至少 20 GB 
+
+NFS：
+
+- RAM: 至少 2 GB
+- CPU: 至少 1 core
+- Disk: 至少 250 GB（再次提醒，這個規格是基於測試網路的用量，如果在正式網路執行，可能需準備更多的儲存空間。）
+
+## 網路需求
+
+- 所有機器皆有網際網路連線能力（至少在安裝過程中）。
+- 主要節點和工作節點網路可以互通。我們在後續的章節會設定 MicroK8s 所需要的防火牆規則，更多細節可參考 [MicroK8s 官方文件](https://microk8s.io/docs/ports)。
+- 主要節點和工作節點皆可連至 NFS 伺服器。
+- 主要節點和工作節點皆可連至為質押挖礦所準備的以太坊 1.0 “Goerli” 節點（請參考「[事前準備](#事前準備)」章節）。
+
+## 事前準備
+
+- 已為 validator 存入足夠的押金，並已產生 validator 金鑰。如果需要參考步驟，我們推薦 [Somer Esat 的教學文章](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3)。
+- 已擁有一個以太坊 1.0 測試網路 Goerli 的節點：[Somer Esat 的教學文章](https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-pyrmont-prysm-a10b5129c7e3)也包含了如何架設以太坊 1.0 的測試網路節點，你也可以選擇使用第三方的服務如 [Infura](https://infura.io/) 或 [Alchemy](https://alchemyapi.io/)。
+- 規劃好內網，設定好防火牆跟轉發通訊埠。在「[設定步驟](#設定步驟)」章節會提到我們使用的網路設定。
+- 已在三台機器安裝 Ubuntu Server 20.04.2 LTS (x64) ，並已指派靜態 IP 位址。
+
+## 設定步驟
+
+### 概要
+
+在這篇教學裡，我們會建立一個 NFS 伺服器，一個 Kubernetes 叢集，並在叢集上安裝以太坊 2.0 beacon 節點及 validator 用戶端。我們將所有的機器放在同一個內網，並指派靜態 IP 位址給每一個機器，以下是我們的網路設定：
+
+**私有內網網段: 172.20.0.0/20 (172.20.0.1 - 172.20.15.254)**
+- NFS IP: 172.20.10.10
+- 主要節點 IP: 172.20.10.11
+- 工作節點 IP: 172.20.10.12
+- DNS: 8.8.8.8, 8.8.4.4 (Google’s DNS)
+
+### 安裝系統更新
+
+請在每一台機器上執行以下命令：
+
+```bash
+sudo apt update && sudo apt upgrade
+sudo apt dist-upgrade && sudo apt autoremove
+sudo reboot
+```
+
+### 同步系統時間
+
+請在每一台機器上執行以下命令：
+
+1. 設定時區，在此以`America/Los_Angeles`為例：
+
+    ```bash
+    timedatectl list-timezones
+    sudo timedatectl set-timezone America/Los_Angeles
+    ```
+
+2. 確認預設的 timekeeping service (NTP service) 有啟動 
+
+    ```bash
+    timedatectl
+    ```
+
+3. 安裝`chrony`
+
+    ```bash
+    sudo apt install chrony
+    ```
+
+4. 編輯`chrony`設定
+
+    ```bash
+    sudo nano /etc/chrony/chrony.conf
+    ```
+
+    加入以下服務器池：
+
+    ```bash
+    pool time.google.com     iburst minpoll 1 maxpoll 2 maxsources 3
+    pool us.pool.ntp.org     iburst minpoll 1 maxpoll 2 maxsources 3
+    pool ntp.ubuntu.com      iburst minpoll 1 maxpoll 2 maxsources 3
+    ```
+
+    更改這兩個設定：
+
+    ```bash
+    maxupdateskew 5.0 # The threshold for determining whether an estimate is too unreliable to be used.
+    makestep 0.1 -1  # This would step the system clock if the adjustment is larger than 0.1 seconds.
+    ```
+
+5. 重新啟動`chrony`服務
+
+    ```bash
+    sudo systemctl restart chronyd
+    ```
+
+6. 確認`chrony`使用的同步資料來源
+
+    ```bash
+    chronyc sources
+    ```
+
+    確認`chrony`的狀態
+
+    ```bash
+    chronyc tracking
+    ```
+
+### 設定防火牆
+
+請在所有機器上執行步驟一至步驟三：
+
+1. 設定預設防火牆規則
+
+    ```bash
+    sudo ufw default deny incoming
+    sudo ufw default allow outgoing
+    ```
+
+2. （**建議**）將`ssh`通訊埠從`22`換成其他通訊埠號以強化安全性。透過編輯`sshd_config`設定檔，將`Port 22`改成其他通訊埠號：
+
+    ```bash
+    sudo nano /etc/ssh/sshd_config
+    ```
+
+    重新啟動`ssh`服務
+
+    ```bash
+    sudo service sshd restart
+    ```
+
+3. 允許 TCP 連線透過`ssh`所使用的通訊埠進入
+
+    ```bash
+    sudo ufw allow <ssh-port>/tcp
+    ```
+
+4. 在 NFS 伺服器上加入 NFS 服務所需的防火牆規則：
+
+    ```bash
+    sudo ufw allow 2049/tcp
+    ```
+
+5. 在主要節點與工作節點的機器上，加入 MicroK8s 所需的防火牆規則：
+
+    ```bash
+    sudo ufw allow 16443/tcp
+    sudo ufw allow 10250/tcp
+    sudo ufw allow 10255/tcp
+    sudo ufw allow 25000/tcp
+    sudo ufw allow 12379/tcp
+    sudo ufw allow 10257/tcp
+    sudo ufw allow 10259/tcp
+    sudo ufw allow 19001/tcp
+    ```
+
+6. 在主要節點與工作節點的機器上，加入 beacon 節點所需的防火牆規則：
+
+    ```bash
+    sudo ufw allow 12000/udp
+    sudo ufw allow 13000/tcp
+    ```
+
+7. 最後，在每一台機器上啟動防火牆服務
+
+    ```bash
+    sudo ufw enable
+    sudo ufw status numbered
+    ```
+
+### 安裝 MicroK8s
+
+你可以直接參考 [MicroK8s 官方文件](https://microk8s.io/docs)，或參考以下步驟來完成安裝與設定。
+
+請在主要節點及工作節點上執行以下命令：
+
+1. 安裝並執行 MicroK8s
+
+    ```bash
+    sudo snap install microk8s --classic --channel=1.20/stable
+    ```
+
+2. 授予非管理員使用者（non-root user）管理 MicroK8s 的權限。將該使用者加入 MicroK8s 的群組中，並改變`~/.kube` 目錄的所有權：
+
+    ```bash
+    sudo usermod -a -G microk8s $USER
+    sudo chown -f -R $USER ~/.kube
+
+    su - $USER # 重新進入該使用者的session來讓改變生效
+    ```
+
+3. 等待 MicroK8s 就緒
+
+    ```bash
+    microk8s status --wait-ready
+    ```
+
+4. 確認所有的節點已就緒
+
+    ```bash
+    microk8s kubectl get node
+    ```
+
+    在輸出的節點清單上，你應只會看到一個節點。
+
+### 建立叢集
+
+在建立叢集前，請確認 MicroK8s 已成功在主要節點及工作節點上執行。
+
+在主要節點上執行以下步驟：
+
+1. 啟動 DNS 和 Helm 3 功能
+
+    ```bash
+    microk8s enable dns helm3
+    ```
+
+2. 使用`add-node`命令產生連接字串，用以讓工作節點加入叢集
+
+    ```bash
+    microk8s add-node
+    ```
+
+    你會看到類似以下輸出結果：
+
+    ```bash
+    Join node with:
+    microk8s join 172.31.20.243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+
+    If the node you are adding is not reachable through the default
+    interface you can use one of the following:
+
+    microk8s join 172.31.20.243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+    microk8s join 10.1.84.0:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+    ```
+
+轉換到工作節點，執行以下步驟：
+
+1. 執行剛剛在主要節點產生的`join`命令，例如：
+
+    ```bash
+    microk8s join 172.31.20.243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+    ```
+
+2. 工作節點成功加入叢集後，請執行以下命令確認兩個節點已準備就緒
+
+    ```bash
+    microk8s kubectl get node
+    ```
+
+### 安裝和設定 NFS
+
+你可以直接參考 [Ubuntu 官方文件](https://ubuntu.com/server/docs/service-nfs)，或參考以下步驟來完成安裝與設定：
+
+在預計執行 NFS 的機器上：
+
+1. 安裝並啟動 NFS 伺服器
+
+    ```bash
+    sudo apt install nfs-kernel-server
+    sudo systemctl start nfs-kernel-server.service
+    ```
+
+2. 為 beacon、validator 用戶端及錢包建資料目錄
+
+    ```bash
+    sudo mkdir -p /data/prysm/beacon
+
+    sudo mkdir -p /data/prysm/validator-client-1 /data/prysm/wallet-1
+    sudo mkdir -p /data/prysm/validator-client-2 /data/prysm/wallet-2
+    ```
+
+    **請注意每一個錢包只能讓一個 validator 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個錢包，並讓一個 validator 用戶端來為多個 validators 提交區塊驗證結果。
+    
+    **為避免 slashing，請不要讓多個 validator 用戶端使用同一個錢包，或將同一把 validator 金鑰匯入多個有 validator 使用的錢包。**
+
+3. 設定並匯出 NFS 儲存空間
+
+    ```bash
+    sudo nano /etc/exports
+    ```
+
+    加入以下的設定並存檔：
+
+    ```bash
+    /data *(rw,sync,no_subtree_check)
+    ```
+
+    設定選項敘述：
+
+    - **\***: hostname 格式 
+    - **rw**: 讀寫權限
+    - **sync**: 在回覆更動要求前，所有的改變都保證會被寫入儲存空間
+    - **no_subtree_check**: 如果設定中包含 no_subtree_check 這個值，之後將不會檢查 subtree。雖然這個設定可能帶來一些安全疑慮，但在某些狀況下，穩定性會因此提升。因為 subtree_checking 比起 no_subtree_check 會造成更多問題，在 nfs-utils 版本 1.1.0 及往後版本，預設值都是 no_subtree_check。
+
+    可以參照 [NFS 伺服器匯出表手冊](https://man7.org/linux/man-pages/man5/exports.5.html)了解其他細節。
+
+    匯出設定
+
+    ```bash
+    sudo exportfs -a
+    ```
+
+
+4. 在主要節點及工作節點上安裝`nfs-common`以支援 NFS：
+
+    ```bash
+    sudo apt install nfs-common
+    ```
+
+### 準備 Validator 錢包
+
+你可以直接參考 [Prysm 官方文件](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm)，或參考以下步驟來完成錢包設定：
+
+在設定錢包前，請先確認 validator 金鑰已經傳到 NFS 伺服器上。這一個章節我們要來用上一章裡建好的錢包目錄來建立錢包並匯入 validator 金鑰。
+
+我們使用 Prysm 提供的腳本來完成設定：
+1. 請參考 [Prysm 官方文件](https://docs.prylabs.network/docs/install/install-with-script/#downloading-the-prysm-startup-script)下載設定腳本（Prysm startup script）
+
+2. 執行腳本時要提供金鑰所在的目錄路徑到`--keys-dir=<path/to/validator-keys>`參數。我們的範例裡使用`$HOME/eth2.0-deposit-cli/validator_keys`當作金鑰目錄
+
+    ```bash
+    sudo ./prysm.sh validator accounts import --keys-dir=$HOME/eth2.0-deposit-cli/validator_keys
+    ```
+
+3. 接著輸入錢包目錄路徑，例如`/data/prysm/wallet-1`
+
+4. 輸入錢包密碼（**記得備份在一個安全的地方！**)
+
+5. 接著輸入 validator 金鑰的密碼（使用 [eth2.0-deposit-cli](https://github.com/ethereum/eth2.0-deposit-cli) 產生 validator 金鑰時所建立的那組密碼）。如果輸入正確，即可成功匯入 validator 帳號至錢包裡。
+
+### 改變資料目錄擁有者
+
+為了讓 Kubernetes 能夠替 beacon 及 validator 用戶端正確地掛載儲存空間，我們必須改變 NFS 上的資料目錄 owner：
+
+```bash
+sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
+```
+
+### 準備 Helm Chart
+
+我們知道要從零開始學習 Kubernetes 以及寫出建立資源的 YAML 文件不是一件簡單的事，所以我們開發了可用來建立 beacon 和 validator 用戶端的 YAML 檔和 Helm Chart，並上傳到 [eth2xk8s](https://github.com/lumostone/eth2xk8s) Github repository 來供大家使用。希望能幫助大家更容易上手！
+
+在這篇教學裡，我們用 Helm 來安裝與升級 beacon 及 validator 用戶端。你也可以不使用 Helm 直接使用 YAML 檔來建立 Kubernetes 資源。細節可以看這兩篇文章：「[使用 Kubernetes manifests、Prysm 以及 hostPath 測試以太坊 2.0 Staking](https://github.com/lumostone/eth2xk8s/blob/master/prysm/host-path/README.md) 」以及「[使用 Kubernetes manifests、Prysm 以及 NFS 測試以太坊 2.0 Staking](https://github.com/lumostone/eth2xk8s/blob/master/prysm/nfs/README.md)」。
+
+1. Clone [eth2xk8s](https://github.com/lumostone/eth2xk8s) Github 專案
+
+    ```bash
+    git clone https://github.com/lumostone/eth2xk8s.git
+    ```
+
+2. 更改 [./prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml) 的值
+
+    建議閱讀`values.yaml`的每個變數及說明，確認是否更改預設值。以下列出安裝 Helm Chart 前必須更改的變數：
+    - **nfs.serverIp**: NFS 伺服器 IP 地址
+    - **nfs.user**: 容器（container）裡的每個程序（process）會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
+    - **nfs.group**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
+    - **image.version**: Prysm 用戶端版本
+    - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
+    - **beacon.web3Provider** 及 **beacon.fallbackWeb3Providers**: 以太坊 1.0 節點網址
+    - **validatorClients.validatorClient1.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
+    - **validatorClients.validatorClient1.walletVolumePath**: NFS 上的錢包資料目錄路徑
+    - **validatorClients.validatorClient1.walletPassword**: 錢包密碼
+
+### 使用 Helm Chart 安裝 Prysm
+
+Kubernetes 使用 [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) 來作命名及資源區隔及存取限制。我們使用`prysm`當作 Prysm 用戶端的 namespace。
+
+Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart 的安裝紀錄。在這篇教學裡，我們用`eth2xk8s`當作我們的 release 名字，你也可以改成其他你想要的名字。
+
+在主要節點上：
+
+1. 創造一個 namespace
+
+    ```bash
+    microk8s kubectl create namespace prysm
+    ```
+
+2. 安裝 Prysm 用戶端
+
+    ```bash
+    microk8s helm3 install eth2xk8s ./prysm/helm -nprysm
+    ```
+
+3. 檢查部署設定
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nprysm
+    ```
+
+### 檢查用戶端狀態
+
+1. 檢查部署狀態
+
+    ```bash
+    microk8s kubectl get pod -nprysm -w
+    ```
+
+    這個指令會持續監控狀態變化，我們只需等到 beacon 及 validator 用戶端都變成 Running 狀態即可。
+
+2. 檢查 beacon 的執行記錄
+
+    ```bash
+    microk8s kubectl logs -f -nprysm -l app=beacon
+    ```
+
+3. 檢查 validator 用戶端的執行記錄
+
+    ```bash
+    microk8s kubectl logs -f -nprysm -l app=validator-client-1
+    ```
+
+    如果想檢查其他的 validator用戶端，可以將`-l app=<validator client name>`更改成在`values.yaml`設定的其他 validator 用戶端的名字，以 validator-client-2 為例
+
+    ```bash
+    microk8s kubectl logs -f -nprysm -l app=validator-client-2
+    ```
+
+### 使用 Helm Chart 更新 Prysm 版本
+
+以太坊 2.0 用戶端的新版本推出速度很快，我們應該盡快更新用戶端版本來獲得最新的 bug fixes 和功能。為了簡化版本跟軟體部署的管理，我們推薦用 Helm 來更新版本：
+
+1. 到 [Prysm Github 版本釋出頁面](https://github.com/prysmaticlabs/prysm/releases)查看最新版本
+
+2. 將`values.yaml`中的 **image.version** 改成最新版本（例如 `v1.3.4`）並儲存`values.yaml`
+
+3. 執行以下 Helm 指令更新用戶端
+
+    ```bash
+    microk8s helm3 upgrade eth2xk8s ./prysm/helm -nprysm
+    ```
+
+4. 檢查部署設定，確認用戶端已更新成新版本
+
+    ```bash
+    microk8s helm3 get manifest eth2xk8s -nprysm
+    ```
+
+5. 依照「[檢查用戶端狀態](#檢查用戶端狀態)」章節檢查用戶端是否正常執行
+
+### 使用 Helm 回溯版本
+
+如果版本回溯不牽涉資料庫 schema 變動的話，使用 Helm 回溯版本就跟更新一樣直覺。以下是範例步驟及指令：
+
+1. 使用`helm history`指令找出並記下想要回溯到的版本號碼
+
+    ```bash
+    microk8s helm3 history eth2xk8s -nprysm
+    ```
+
+2. 回溯到指定版本（以下指令假設我們要回溯到版本 4）
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nprysm
+    ```
+
+3. 接著依照「[檢查用戶端狀態](#檢查用戶端狀態)」章節檢查部署設定以及用戶端是否正常執行。
+
+如果版本回溯前需要先還原資料庫 schema，可以參照「[使用 Helm 回溯版本（如果資料庫 Schema 有更動)](#使用-helm-回溯版本如果資料庫-schema-有更動)」章節。
+
+某些情況下有可能沒辦法回溯到之前的版本（[例子](https://docs.prylabs.network/docs/prysm-usage/staying-up-to-date/#downgrading-between-major-version-bumps)），在回溯前記得先確認用戶端相關文件。
+
+## 結論
+
+感謝你的閱讀！我們希望這篇文章能夠幫助想要使用 Kubernetes 來做以太坊 2.0 staking 的你。我們會繼續製作相關教學，之後我們也會開發給其他以太坊 2.0 用戶端的 Helm Chart。敬請期待！
+
+## 有任何建議或是疑問嗎？
+
+請讓我們知道你的想法！如果對這篇文章有任何問題及建議都歡迎到我們[網站的 Github 專案](https://github.com/lumostone/lumostone.github.io)開 issue 或是發 pull request。如果你對於貢獻以太坊 2.0 Staking 的 Helm Chart 有興趣，請將 issue 或 pull request 發至 [eth2xk8s](https://github.com/lumostone/eth2xk8s) 跟我們聯繫。
+
+## 附錄
+
+### 檢查 CPU 及記憶體用量
+
+如果想知道每個 pod 的 CPU 及記憶體用量，可以使用 Github 開源專案 [metrics server](https://github.com/kubernetes-sigs/metrics-server) 來取得資料。
+
+1. 首先，用以下的指令在 Kubernetes 叢集上安裝 metrics server
+
+    ```bash
+    microk8s kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+    ```
+
+2. 接著可以執行`kubectl top`指令來得到用量資訊，下面兩個例子分別會得到 beacon 及 validator 用戶端的用量。
+
+    ```bash
+    microk8s kubectl top pod -l app=beacon
+    microk8s kubectl top pod -l app=validator-client-1
+    ```
+
+### 解除安裝 Helm Chart
+
+如果想要停止執行以及移除 Prysm，可以執行以下指令來移除整個 Helm Chart：
+
+```bash
+microk8s helm3 uninstall eth2xk8s -nprysm
+```
+
+### 使用 Helm 回溯版本（如果資料庫 Schema 有更動）
+
+以 [Prysm v1.3.0 版本](https://github.com/prysmaticlabs/prysm/releases/tag/v1.3.0)為例，如果想要回溯至 v1.2.x，我們需要在回溯前先跑一個腳本來還原 v1.3.0 帶來的資料庫 schema 變動。所以如果我們照著「[使用 Helm 回溯版本](#使用-helm-回溯版本)」的步驟執行指令，在用 Helm 改變 Prsym 版本成 v1.2.2 之後，所有的 pods 會馬上重啟，但 Prysm 可能會因為資料庫 schema 只適用於 v1.3.0 版本而無法正常啟動。
+
+要解決這個問題，我們可以利用 Kubernetes 暫時把 pod 的數量降成 0。在此期間，不會有任何 Prysm 程式能夠執行，我們也就能趁機執行腳本復原新版本帶來的 schema 變動，然後再恢復 pod 的數量，最後再回溯版本。以下是範例步驟及指令：
+
+1. 在還原版本前，用以下指令先把 pod 的數量降成 0
+
+    只調整 beacon：
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nprysm --replicas=0
+    ```
+
+    如果 schema 變動只影響 validator，我們可以只調整 validator 用戶端：
+
+    ```bash
+    microk8s kubectl scale deployments/validator-client-1 -nprysm --replicas=0
+    ```
+
+2. 確認所有 pod 都已停止
+
+    ```bash
+    microk8s kubectl get pod -nprysm -w
+    ```
+
+3. 執行腳本復原 schema 變動
+
+4. 回溯到版本 4
+
+    ```bash
+    microk8s helm3 rollback eth2xk8s 4 -nprysm
+    ```
+
+5. 恢復 beacon 及 validator 用戶端 pod 的數量
+
+    ```bash
+    microk8s kubectl scale deployments/beacon -nprysm --replicas=1
+    microk8s kubectl scale deployments/validator-client-1 -nprysm --replicas=1
+    ```
+
+6. 確認所有 pod 都恢復執行
+
+    ```bash
+    microk8s kubectl get pod -nprysm -w
+    ```

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -417,7 +417,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
 
 我們知道要從零開始學習 Kubernetes 以及寫出建立資源的 YAML 文件不是一件簡單的事，所以我們開發了可用來建立 beacon 和 validator 用戶端的 YAML 檔和 Helm Chart，並上傳到 [eth2xk8s](https://github.com/lumostone/eth2xk8s) Github repository 來供大家使用。希望能幫助大家更容易上手！
 
-在這篇教學裡，我們用 Helm 來安裝與升級 beacon 及 validator 用戶端。你也可以不使用 Helm 直接使用 YAML 檔來建立 Kubernetes 資源。細節可以看這兩篇文章：「[使用 Kubernetes manifests、Prysm 以及 hostPath 測試以太坊 2.0 Staking](https://github.com/lumostone/eth2xk8s/blob/master/prysm/host-path/README.md) 」以及「[使用 Kubernetes manifests、Prysm 以及 NFS 測試以太坊 2.0 Staking](https://github.com/lumostone/eth2xk8s/blob/master/prysm/nfs/README.md)」。
+在這篇教學裡，我們用 Helm 來安裝與升級 beacon 及 validator 用戶端。你也可以不使用 Helm 直接使用 YAML 檔來建立 Kubernetes 資源。細節可以看這兩篇文章：「[使用 Kubernetes manifests 以及 hostPath 測試以太坊 2.0 Staking](https://github.com/lumostone/eth2xk8s/blob/master/testing-with-host-path.md) 」以及「[使用 Kubernetes manifests 以及 NFS 測試以太坊 2.0 Staking](https://github.com/lumostone/eth2xk8s/blob/master/testing-with-nfs.md)」。
 
 1. Clone [eth2xk8s](https://github.com/lumostone/eth2xk8s) Github 專案
 
@@ -425,7 +425,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     git clone https://github.com/lumostone/eth2xk8s.git
     ```
 
-2. 更改 [./prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml) 的值
+2. 更改 [prysm/helm/values.yaml](https://github.com/lumostone/eth2xk8s/blob/master/prysm/helm/values.yaml) 的值
 
     建議閱讀`values.yaml`的每個變數及說明，確認是否更改預設值。以下列出安裝 Helm Chart 前必須更改的變數：
     - **nfs.serverIp**: NFS 伺服器 IP 地址

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -561,7 +561,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
     - **image.versionTag**: Prysm 用戶端版本
     - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
-    - **beacon.web3Provider** 及 **beacon.fallbackWeb3Providers**: 以太坊 1.0 節點網址
+    - **beacon.eth1Endpoints**: 以太坊 1.0 節點網址
     - **validatorClients.validatorClient1**
       - **.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
       - **.walletVolumePath**: NFS 上的錢包資料目錄路徑
@@ -592,7 +592,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
     - **image.versionTag**: Teku 用戶端版本
     - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
-    - **beacon.eth1Endpoint**: 以太坊 1.0 節點網址
+    - **beacon.eth1Endpoints**: 以太坊 1.0 節點網址
     - **validatorClients.validatorClient1**
       - **.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
       - **.validatorKeysVolumePath**: NFS 上的 validator 金鑰資料目錄路徑
@@ -609,7 +609,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
     - **image.versionTag**: Nimbus 用戶端版本
     - **nimbus.clients.client1**
-      - **.web3Provider** 及 **.fallbackWeb3Providers**: 以太坊 1.0 節點網址
+      - **.eth1Endpoints**: 以太坊 1.0 節點網址
       - **.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
       - **.validatorsVolumePath**: NFS 上的 validator 金鑰存放區資料目錄路徑
       - **.secretsVolumePath**: NFS 上的 validator 金鑰存放區秘密資料目錄路徑

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -616,7 +616,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
 
 {{< /toggle-panel >}}
 
-### 使用 Helm Chart 安裝 Prysm
+### 使用 Helm Chart 安裝以太坊 2.0 用戶端
 
 Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart 的安裝紀錄。在這篇教學裡，我們用`eth2xk8s`當作我們的 release 名字，你也可以改成其他你想要的名字。我們會在安裝 Helm Chart 時指定要安裝在什麼 [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) 內（Kubernetes 使用 namespace 來區隔資源及限制存取）。
 
@@ -830,7 +830,7 @@ Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart �
 
 {{< /toggle-panel >}}
 
-### 使用 Helm Chart 更新 Prysm 版本
+### 使用 Helm Chart 更新以太坊 2.0 用戶端版本
 
 以太坊 2.0 用戶端的新版本推出速度很快，我們應該盡快更新用戶端版本來獲得最新的 bug fixes 和功能。為了簡化版本跟軟體部署的管理，我們推薦用 Helm 來更新版本：
 

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -1,6 +1,6 @@
 ---
 title: "當以太幣質押挖礦機遇見 Kubernetes－架設教學"
-date: 2021-04-19T23:53:09Z
+date: 2021-05-07T23:53:09Z
 draft: true
 tags: ["以太坊", "kubernetes", "教學"]
 aliases:
@@ -29,26 +29,7 @@ aliases:
 
 這份教學將示範如何在一個 Kubernetes 叢集上維運一個以太坊 2.0 beacon 用戶端和多個 validator 用戶端， 以下是我們使用的工具：
 
-- {{< toggle-panel name="Prysm" active=true >}}
-
-[Prysm](https://github.com/prysmaticlabs/prysm) 以太坊 2.0 用戶端
-
-{{< /toggle-panel >}}
-{{< toggle-panel name="Lighthouse" >}}
-
-[Lighthouse](https://github.com/sigp/lighthouse) 以太坊 2.0 用戶端
-
-{{< /toggle-panel >}}
-{{< toggle-panel name="Teku" >}}
-
-[Teku](https://github.com/ConsenSys/teku) 以太坊 2.0 用戶端
-
-{{< /toggle-panel >}}
-{{< toggle-panel name="Nimbus" >}}
-
-[Nimbus](https://github.com/status-im/nimbus-eth2) 以太坊 2.0 用戶端
-
-{{< /toggle-panel >}}
+- 以太坊 2.0 用戶端 ([Prysm](https://github.com/prysmaticlabs/prysm), [Lighthouse](https://github.com/sigp/lighthouse), [Teku](https://github.com/ConsenSys/teku) 或是 [Nimbus](https://github.com/status-im/nimbus-eth2))
 - [MicroK8s](https://microk8s.io/) 輕量的 Kubernertes 發行版（[安裝教學](https://microk8s.io/docs)）
 - [Helm 3](https://helm.sh/) Kubernetes 套件管理工具
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) Kubernetes CLI 工具

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -105,7 +105,7 @@ NFS：
 
 ### 選擇以太坊 2.0 用戶端
 
-之後的教學內容會根據你選擇的以太坊 2.0 用戶端而有所變動，請在繼續往下閱讀前選則一個用戶端：
+之後的教學內容會根據你選擇的以太坊 2.0 用戶端而有所變動，請在繼續往下閱讀前選擇一個用戶端：
 {{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" active="toggle1" >}}
 
 ### 概要

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -426,7 +426,7 @@ sudo ufw allow 9000
     sudo mkdir -p /data/nimbus/beacon-2 /data/nimbus/validators-2 /data/nimbus/secrets-2
     ```
 
-    **P請注意每一個金鑰只能讓一個 Nimbus 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個用戶端，並讓一個用戶端來為多個 validators 金鑰提交區塊驗證結果。
+    **請注意每一個金鑰只能讓一個 Nimbus 用戶端使用。** 你可以匯入多個 validator 金鑰到同一個用戶端，並讓一個用戶端來為多個 validators 金鑰提交區塊驗證結果。
 
     **為避免 slashing，請不要匯入同一個金鑰到多個 Nimbus 用戶端。**
 
@@ -512,7 +512,7 @@ sudo ufw allow 9000
     sudo cp  $HOME/eth2.0-deposit-cli/validator_keys/* /data/teku/validator-keys-1/
     ```
 
-2. 替每一把金鑰產生一個相對應的 txt 密碼檔（使用`eth2.0-deposit-cli`產生 validator 金鑰時所建立的那組密碼），並將密碼檔們移到們預計存放密碼的目錄裡（假設是`/data/teku/validator-key-passwords-1`）。例如，如果有一把金鑰的名稱是`keystore-m_123.json`, 我們需要產一個名為`keystore-m_123.txt`的檔案並把密碼存在檔案裡
+2. 替每一把金鑰產生一個相對應的 txt 密碼檔（使用`eth2.0-deposit-cli`產生 validator 金鑰時所建立的那組密碼），並將密碼檔們移到預計存放密碼的目錄裡（假設是`/data/teku/validator-key-passwords-1`）。例如，如果有一把金鑰的名稱是`keystore-m_123.json`, 我們需要產生一個名為`keystore-m_123.txt`的檔案並把密碼存在檔案裡
 
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
@@ -609,7 +609,7 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
     - **image.versionTag**: Nimbus 用戶端版本
     - **nimbus.clients.client1**
-      - **.web3Provider** and **.fallbackWeb3Providers**: 以太坊 1.0 節點網址
+      - **.web3Provider** 及 **.fallbackWeb3Providers**: 以太坊 1.0 節點網址
       - **.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
       - **.validatorsVolumePath**: NFS 上的 validator 金鑰存放區資料目錄路徑
       - **.secretsVolumePath**: NFS 上的 validator 金鑰存放區秘密資料目錄路徑
@@ -1014,8 +1014,7 @@ Helm 使用 [releases](https://helm.sh/docs/glossary/#release) 來追蹤 chart �
     microk8s kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
     ```
 
-2. 接著可以執行`kubectl top`指令來得到用量資訊，下面兩個例子分別會得到 beacon 及 validator 用戶端的用量。
-
+2. 接著可以執行`kubectl top`指令來得到用量資訊：
 {{< toggle-panel name="Prysm" active=true >}}
 
 ```bash

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -3,9 +3,11 @@ title: "當以太幣質押挖礦機遇見 Kubernetes－架設教學"
 date: 2021-04-19T23:53:09Z
 draft: true
 tags: ["以太坊", "kubernetes", "教學"]
+aliases:
+    - /zh-tw/eth2-staking-with-k8s-prysm/
 ---
 
-{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" >}}
+{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" active="toggle1" >}}
 
 ## 為什麼使用 Kubernetes 作 staking？
 作為 staker，我們常擔憂 validator 是否會突然停機，或是被區塊鏈上其他節點認作是壞成員而遭到驅逐（slashing）。如何最小化停機時間和降低被驅逐的風險，成為了一個 staker 時常考慮的問題。

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -560,11 +560,11 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **securityContext.runAsUse**: 容器裡的每個程序會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
     - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
     - **image.versionTag**: Prysm 用戶端版本
-    - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
+    - **beacon.dataDirPath**: NFS 上的 beacon 資料目錄路徑
     - **beacon.eth1Endpoints**: 以太坊 1.0 節點網址
     - **validatorClients.validatorClient1**
-      - **.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
-      - **.walletVolumePath**: NFS 上的錢包資料目錄路徑
+      - **.dataDirPath**: NFS 上的 validator 用戶端資料目錄路徑
+      - **.walletDirPath**: NFS 上的錢包資料目錄路徑
       - **.walletPassword**: 錢包密碼
 
 {{< /toggle-panel >}}
@@ -577,9 +577,9 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **securityContext.runAsUse**: 容器裡的每個程序會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
     - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
     - **image.versionTag**: Lighthouse 用戶端版本
-    - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
+    - **beacon.dataDirPath**: NFS 上的 beacon 資料目錄路徑
     - **beacon.eth1Endpoints**: 以太坊 1.0 節點網址
-    - **validatorClients.validatorClient1.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
+    - **validatorClients.validatorClient1.dataDirPath**: NFS 上的 validator 用戶端資料目錄路徑
 
 {{< /toggle-panel >}}
 {{< toggle-panel name="Teku" >}}
@@ -591,12 +591,12 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **securityContext.runAsUse**: 容器裡的每個程序會使用這個 user ID 來執行。這個使用者需擁有存取掛載的 NFS 資料目錄路徑的權限。
     - **securityContext.runAsGroup**: 容器裡的每個程序會使用這個 group ID 來執行。這個群組需擁有存取掛載的 NFS 資料目錄路徑的權限。我們用此來給予程序有限的權限，不然預設 Kubernetes 會使用 root 群組執行程序。
     - **image.versionTag**: Teku 用戶端版本
-    - **beacon.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
+    - **beacon.dataDirPath**: NFS 上的 beacon 資料目錄路徑
     - **beacon.eth1Endpoints**: 以太坊 1.0 節點網址
     - **validatorClients.validatorClient1**
-      - **.dataVolumePath**: NFS 上的 validator 用戶端資料目錄路徑
-      - **.validatorKeysVolumePath**: NFS 上的 validator 金鑰資料目錄路徑
-      - **.validatorKeyPasswordsVolumePath**: NFS 上的 validator 金鑰密碼資料目錄路徑
+      - **.dataDirPath**: NFS 上的 validator 用戶端資料目錄路徑
+      - **.validatorKeysDirPath**: NFS 上的 validator 金鑰資料目錄路徑
+      - **.validatorKeyPasswordsDirPath**: NFS 上的 validator 金鑰密碼資料目錄路徑
 
 {{< /toggle-panel >}}
 {{< toggle-panel name="Nimbus" >}}
@@ -610,9 +610,9 @@ sudo chown -R 1001:2000 /data # you can pick other user ID and group ID
     - **image.versionTag**: Nimbus 用戶端版本
     - **nimbus.clients.client1**
       - **.eth1Endpoints**: 以太坊 1.0 節點網址
-      - **.dataVolumePath**: NFS 上的 beacon 資料目錄路徑
-      - **.validatorsVolumePath**: NFS 上的 validator 金鑰存放區資料目錄路徑
-      - **.secretsVolumePath**: NFS 上的 validator 金鑰存放區秘密資料目錄路徑
+      - **.dataDirPath**: NFS 上的 beacon 資料目錄路徑
+      - **.validatorsDirPath**: NFS 上的 validator 金鑰存放區資料目錄路徑
+      - **.secretsDirPath**: NFS 上的 validator 金鑰存放區秘密資料目錄路徑
 
 {{< /toggle-panel >}}
 

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -27,7 +27,7 @@ aliases:
 
 ## 使用工具
 
-這份教學將示範如何在一個 Kubernetes 叢集上維運一個以太坊 2.0 beacon 用戶端和多個 validator 用戶端， 以下是我們使用的工具：
+這份教學將示範如何在一個 Kubernetes 叢集上維運多個以太坊 2.0 用戶端， 以下是我們使用的工具：
 
 - 以太坊 2.0 用戶端 ([Prysm](https://github.com/prysmaticlabs/prysm), [Lighthouse](https://github.com/sigp/lighthouse), [Teku](https://github.com/ConsenSys/teku) 或是 [Nimbus](https://github.com/status-im/nimbus-eth2))
 - [MicroK8s](https://microk8s.io/) 輕量的 Kubernertes 發行版（[安裝教學](https://microk8s.io/docs)）

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -1,9 +1,11 @@
 ---
 title: "當以太幣質押挖礦機遇見 Kubernetes－架設教學"
 date: 2021-04-19T23:53:09Z
-draft: false
+draft: true
 tags: ["以太坊", "kubernetes", "教學"]
 ---
+
+{{< content-toggle toggleTotal="4" toggle1="Prysm" toggle2="Lighthouse" toggle3="Teku" toggle4="Nimbus" >}}
 
 ## 為什麼使用 Kubernetes 作 staking？
 作為 staker，我們常擔憂 validator 是否會突然停機，或是被區塊鏈上其他節點認作是壞成員而遭到驅逐（slashing）。如何最小化停機時間和降低被驅逐的風險，成為了一個 staker 時常考慮的問題。

--- a/content/zh-tw/posts/eth2-staking-with-k8s.md
+++ b/content/zh-tw/posts/eth2-staking-with-k8s.md
@@ -386,7 +386,7 @@ sudo reboot
     sudo apt install nfs-common
     ```
 
-### 準備 Validator 錢包
+### 匯入 Validator 金鑰
 
 你可以直接參考 [Prysm 官方文件](https://docs.prylabs.network/docs/mainnet/joining-eth2/#step-4-import-your-validator-accounts-into-prysm)，或參考以下步驟來完成錢包設定：
 

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -1,0 +1,10 @@
+<script src="{{ "js/jquery-3.5.1.min.js" | absURL }}"></script>
+<link href="{{ "css/fancybox.min.css" | absURL }}" rel="stylesheet">
+<script src="{{ "js/fancybox.min.js" | absURL }}"></script>
+<script src="{{ "js/zozo.js" | absURL }}"></script>
+<script src="{{ "js/tab.js" | absURL }}"></script>
+<script src="{{ "js/eth2client.js" | absURL }}"></script>
+
+{{ if .Site.Params.enableMathJax }}
+{{ partial "mathjax.html" . }}
+{{ end }}

--- a/static/js/eth2client.js
+++ b/static/js/eth2client.js
@@ -1,0 +1,4 @@
+$(document).ready(function () {
+    const urlParams = new URLSearchParams(window.location.search);
+    $(".content-toggle button[title='toggle-" + urlParams.get("client") + "']").trigger("click");
+});


### PR DESCRIPTION
- Allow specify client in the URL. (e.g. ?client=Lighthouse)
- Change from version to versionTag. Rename to eth1Endpoints. Rename xxVolumePath to xxDirPath
- Change the link of SomerEsat guide to a more general one. 
- Update README links and path format.
- Change contentDir from /content/lang-code/posts to /content/lang-code for i18n (e.g. /content/en)
- Add aliases for the new articles so that old link will be redirected to the new articles.
- Update the title from 'Prepare Validator Wallets' to 'Import Validator Keys'.
- Mention all clients in the technology section.
- Remove Prysm from the section titles.

Co-authored-by: Ching-Yi Lin <lofox.cylin@gmail.com>